### PR TITLE
Add Semaphore locking for installId

### DIFF
--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -29,7 +29,7 @@ internal enum KumulosEvent : String {
 // MARK: class
 open class Kumulos {
 
-    static let installIdLock = DispatchSemaphore(value: 1)
+    private static let installIdLock = DispatchSemaphore(value: 1)
     
     internal let baseApiUrl = "https://api.kumulos.com/b2.2"
     internal let basePushUrl = "https://push.kumulos.com/v1"
@@ -108,7 +108,7 @@ open class Kumulos {
             if let existingID = UserDefaults.standard.object(forKey: "KumulosUUID") {
                 return existingID as! String
             }
-            
+
             let newID = UUID().uuidString
             UserDefaults.standard.set(newID, forKey: "KumulosUUID")
             UserDefaults.standard.synchronize()

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -29,6 +29,8 @@ internal enum KumulosEvent : String {
 // MARK: class
 open class Kumulos {
 
+    static let installIdLock = DispatchSemaphore(value: 1)
+    
     internal let baseApiUrl = "https://api.kumulos.com/b2.2"
     internal let basePushUrl = "https://push.kumulos.com/v1"
     internal let baseCrashUrl = "https://crash.kumulos.com/v1"
@@ -98,13 +100,19 @@ open class Kumulos {
     */
     public static var installId :String {
         get {
+            installIdLock.wait()
+            defer {
+                installIdLock.signal()
+            }
+            
             if let existingID = UserDefaults.standard.object(forKey: "KumulosUUID") {
                 return existingID as! String
             }
-
+            
             let newID = UUID().uuidString
             UserDefaults.standard.set(newID, forKey: "KumulosUUID")
             UserDefaults.standard.synchronize()
+            
             return newID
         }
     }


### PR DESCRIPTION
* If multiple threads request the installId on first start, then prevent each thread writing their own installId to user defaults.