### PR TITLE
Rename of push unsubscribe method to be semantic inverse of subscribe method

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -189,7 +189,7 @@
 			};
 			buildConfigurationList = DB481C141D3BC9D30021C627 /* Build configuration list for PBXProject "KumulosSDK" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "3.1.0"
+  s.version = "4.0.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 3.1'
+pod 'KumulosSdkSwift', '~> 4.0'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 3.1
+github "Kumulos/KumulosSdkSwift" ~> 4.0
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.0</string>
+	<string>4.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/Kumulos+API.swift
+++ b/Sources/Kumulos+API.swift
@@ -24,7 +24,7 @@ public extension Kumulos {
         - Parameters:
             - methodName: The alias of your API method
     */
-    public static func call(_ methodName: String) -> KSAPIOperation {
+    static func call(_ methodName: String) -> KSAPIOperation {
         return performMethod(methodName, kumulosParameters: nil)
     }
 
@@ -35,7 +35,7 @@ public extension Kumulos {
             - methodName: The alias of your API method
             - parameters: A dictionary of parameters for your method
      */
-    public static func call(_ methodName: String, parameters: Dictionary<String, AnyObject>) -> KSAPIOperation {
+    static func call(_ methodName: String, parameters: Dictionary<String, AnyObject>) -> KSAPIOperation {
         return performMethod(methodName, kumulosParameters: parameters)
     }
 

--- a/Sources/Kumulos+Analytics.swift
+++ b/Sources/Kumulos+Analytics.swift
@@ -23,7 +23,7 @@ public extension Kumulos {
      - eventType: Unique identifier for the type of event
      - properties: Optional meta-data about the event
      */
-    public static func trackEvent(eventType: String, properties: [String:Any]?) {
+    static func trackEvent(eventType: String, properties: [String:Any]?) {
         getInstance().analyticsHelper?.trackEvent(eventType: eventType, properties: properties, immediateFlush: false)
     }
     
@@ -34,7 +34,7 @@ public extension Kumulos {
      - eventType: Unique identifier for the type of event
      - properties: Optional meta-data about the event
      */
-    public static func trackEventImmediately(eventType: String, properties: [String:Any]?) {
+    static func trackEventImmediately(eventType: String, properties: [String:Any]?) {
         getInstance().analyticsHelper?.trackEvent(eventType: eventType, properties: properties, immediateFlush: true)
     }
     
@@ -44,7 +44,7 @@ public extension Kumulos {
      Parameters:
      - userIdentifier: Unique identifier for the current user
      */
-    public static func associateUserWithInstall(userIdentifier: String) {
+    static func associateUserWithInstall(userIdentifier: String) {
         associateUserWithInstallImpl(userIdentifier: userIdentifier, attributes: nil)
     }
     
@@ -55,7 +55,7 @@ public extension Kumulos {
      - userIdentifier: Unique identifier for the current user
      - attributes: JSON encodable dictionary of attributes to store for the user
      */
-    public static func associateUserWithInstall(userIdentifier: String, attributes: [String:AnyObject]) {
+    static func associateUserWithInstall(userIdentifier: String, attributes: [String:AnyObject]) {
         associateUserWithInstallImpl(userIdentifier: userIdentifier, attributes: attributes)
     }
 
@@ -64,7 +64,7 @@ public extension Kumulos {
 
      If no user is associated, it returns the Kumulos installation ID
     */
-    public static var currentUserIdentifier : String {
+    static var currentUserIdentifier : String {
         get {
             userIdLock.wait()
             defer { userIdLock.signal() }
@@ -81,7 +81,7 @@ public extension Kumulos {
 
      See associateUserWithInstall and currentUserIdentifier for further information.
      */
-    public static func clearUserAssociation() {
+    static func clearUserAssociation() {
         userIdLock.wait()
         let currentUserId = UserDefaults.standard.value(forKey: USER_ID_KEY)
         userIdLock.signal()

--- a/Sources/Kumulos+Crash.swift
+++ b/Sources/Kumulos+Crash.swift
@@ -31,7 +31,7 @@ public extension Kumulos {
         }
     }
     
-    public static func logException(name: String, reason: String, language: String, lineOfCode: String, stackTrace: [Any], logAllThreads: Bool)  {
+    static func logException(name: String, reason: String, language: String, lineOfCode: String, stackTrace: [Any], logAllThreads: Bool)  {
         KSCrash.sharedInstance().reportUserException(name, reason: reason, language: language, lineOfCode: lineOfCode, stackTrace: stackTrace, logAllThreads: logAllThreads, terminateProgram: false)
         
         KSCrash.sharedInstance().sendAllReports{ (reports, completed, error) -> Void in

--- a/Sources/Kumulos+Engage.swift
+++ b/Sources/Kumulos+Engage.swift
@@ -10,7 +10,7 @@ import CoreLocation
 
 public extension Kumulos{
     
-    public static func sendLocationUpdate(location: CLLocation) {
+    static func sendLocationUpdate(location: CLLocation) {
         let parameters = [
             "lat" : location.coordinate.latitude,
             "lng" : location.coordinate.longitude
@@ -19,7 +19,7 @@ public extension Kumulos{
         Kumulos.trackEvent(eventType: KumulosEvent.ENGAGE_LOCATION_UPDATED, properties: parameters, immediateFlush: true)
     }
     
-    public static func sendiBeaconProximity(beacon: CLBeacon) {
+    static func sendiBeaconProximity(beacon: CLBeacon) {
         
         let parameters = [
             "type": 1,

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -14,7 +14,7 @@ public extension Kumulos{
 
         On success will raise the didRegisterForRemoteNotificationsWithDeviceToken UIApplication event
     */
-    public static func pushRequestDeviceToken() {
+    static func pushRequestDeviceToken() {
         if #available(iOS 10.0, *) {
             let center = UNUserNotificationCenter.current()
             center.requestAuthorization(options: [.alert, .badge, .sound]) { (granted, error) in
@@ -48,7 +48,7 @@ public extension Kumulos{
         Parameters:
             - deviceToken: The push token returned by the device
     */
-    public static func pushRegister(_ deviceToken: Data) {
+    static func pushRegister(_ deviceToken: Data) {
         let token = serializeDeviceToken(deviceToken)
         let iosTokenType = getTokenType()
 
@@ -60,7 +60,7 @@ public extension Kumulos{
     /**
         Unsubscribe your device from the Kumulos Push service
     */
-    public static func pushTokenDelete() {
+    static func pushUnregister() {
         Kumulos.trackEvent(eventType: KumulosEvent.DEVICE_UNSUBSCRIBED, properties: [:], immediateFlush: true)
     }
  
@@ -70,7 +70,7 @@ public extension Kumulos{
         Parameters:
             - notification: The notification which triggered the action
     */
-    public static func pushTrackOpen(notification: [AnyHashable: Any]) {
+    static func pushTrackOpen(notification: [AnyHashable: Any]) {
         if let custom = notification["custom"] as? [String:AnyObject], let id = custom["i"]
         {
             let parameters = ["id" : id]

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -41,7 +41,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal(set) var networkRequestsInProgress = 0
+    var networkRequestsInProgress = 0
 
     fileprivate static var instance:Kumulos?
 


### PR DESCRIPTION
Rename pushTokenDelete -> pushUnregister as the inverse of pushRegister
Bump versioning
Resolve xcode 10.2 build warnings