### PR TITLE
Support pictures in push notifications

### DIFF
--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "6.0.0"
+  s.version = "6.1.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 6.0'
+pod 'KumulosSdkSwift', '~> 6.1'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 6.0
+github "Kumulos/KumulosSdkSwift" ~> 6.1
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.0</string>
+	<string>6.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -48,7 +48,8 @@ public class KSPushNotification: NSObject {
 }
 
 public extension Kumulos {
-
+    
+    internal static let KS_MEDIA_RESIZER_BASE_URL = "https://i.app.delivery"
     /**
         Helper method for requesting the device token with alert, badge and sound permissions.
 
@@ -175,6 +176,108 @@ public extension Kumulos {
         }
         
         return Kumulos.sharedInstance.pushNotificationProductionTokenType
+    }
+    
+    //MARK: Notification Service Extension
+    
+    @available(iOS 10.0, *)
+    class func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+        let bestAttemptContent =  (request.content.mutableCopy() as! UNMutableNotificationContent)
+
+        let userInfo = request.content.userInfo
+        let attachments = userInfo["attachments"] as? [AnyHashable : Any]
+        let pictureUrl = attachments?["pictureUrl"] as? String
+
+        if pictureUrl == nil {
+            contentHandler(bestAttemptContent)
+            return
+        }
+
+        let picExtension = getPictureExtension(pictureUrl)
+        let url = getCompletePictureUrl(pictureUrl!)
+        
+        if (url == nil){
+            contentHandler(bestAttemptContent)
+            return
+        }
+        
+        loadAttachment(url!, withExtension: picExtension, completionHandler: { attachment in
+               if attachment != nil {
+                   bestAttemptContent.attachments = [attachment!]
+               }
+               contentHandler(bestAttemptContent)
+           })
+        
+    }
+        
+    class func getPictureExtension(_ pictureUrl: String?) -> String? {
+        if (pictureUrl == nil){
+            return nil;
+        }
+        let pictureExtension = URL(fileURLWithPath: pictureUrl!).pathExtension
+        if (pictureExtension == "") {
+            return nil
+        }
+
+        return "." + (pictureExtension)
+    }
+    
+    class func getCompletePictureUrl(_ pictureUrl: String) -> URL? {
+        if (((pictureUrl as NSString).substring(with: NSRange(location: 0, length: 8))) == "https://") || (((pictureUrl as NSString).substring(with: NSRange(location: 0, length: 7))) == "http://") {
+            return URL(string: pictureUrl)
+        }
+
+        let width = UIScreen.main.bounds.size.width
+        let num = Int(floor(width))
+
+        let completeString = String(format: "%@%@%ld%@%@", KS_MEDIA_RESIZER_BASE_URL, "/", num, "x/", pictureUrl)
+        return URL(string: completeString)
+    }
+
+    @available(iOS 10.0, *)
+    class func loadAttachment(_ url: URL, withExtension pictureExtension: String?, completionHandler: @escaping (UNNotificationAttachment?) -> Void) {
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+        
+        (session.downloadTask(with: url, completionHandler: { temporaryFileLocation, response, error in
+            if error != nil {
+                print("NotificationServiceExtension: \(error!.localizedDescription)")
+                completionHandler(nil)
+                return
+            }
+
+            var finalExt = pictureExtension
+            if finalExt == nil {
+                finalExt = self.getPictureExtension(response?.suggestedFilename)
+                if finalExt == nil {
+                    completionHandler(nil)
+                    return
+                }
+            }
+            
+            if (temporaryFileLocation == nil){
+                completionHandler(nil)
+                return
+            }
+
+            let fileManager = FileManager.default
+            let localURL = URL(fileURLWithPath: temporaryFileLocation!.path + (finalExt!))
+            do {
+                try fileManager.moveItem(at: temporaryFileLocation!, to: localURL)
+            } catch {
+                completionHandler(nil)
+                return
+            }
+
+          
+            var attachment: UNNotificationAttachment? = nil
+            do {
+                attachment = try UNNotificationAttachment(identifier: "", url: localURL, options: nil)
+            } catch let attachmentError {
+                print("NotificationServiceExtension: attachment error: \(attachmentError.localizedDescription)")
+            }
+           
+            completionHandler(attachment)
+        })).resume()
     }
 }
 

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -60,7 +60,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
     
-    internal let sdkVersion : String = "6.0.0"
+    internal let sdkVersion : String = "6.1.0"
 
     var networkRequestsInProgress = 0
 


### PR DESCRIPTION
### Description of Changes

Add Notification Service Extension to support pictures in push notifications. Implementation of the extension is added to Kumulos + Push. Users have to perform following steps to enable the functionality:

1) add Notification Service Extension to an application
2) replace contents of `didReceive` (NotificationService) with `Kumulos.didReceive(request, withContentHandler: contentHandler)`
3) Make sure Notification Service's deployment target matches test device

Works on ios 10+, notifications expand only on devices that have 3D Touch

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `Sources/Info-*.plist`
-   [x] `README.md`

Release:

-   [x] Squash and merge to master
-   [x] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

