### PR TITLE
Copy field values when mapping InAppMessageEntity into InAppMessage models

### DIFF
--- a/Sources/InApp/InAppModels.swift
+++ b/Sources/InApp/InAppModels.swift
@@ -31,13 +31,13 @@ public class InAppMessage: NSObject {
     internal(set) open var dismissedAt : NSDate?
     
     init(entity: InAppMessageEntity) {
-        id = entity.id
-        updatedAt = entity.updatedAt
-        content = entity.content
-        data = entity.data
-        badgeConfig = entity.badgeConfig
-        inboxConfig = entity.inboxConfig
-        dismissedAt = entity.dismissedAt
+        id = Int64(entity.id)
+        updatedAt = entity.updatedAt.copy()
+        content = entity.content.copy()
+        data = entity.data?.copy()
+        badgeConfig = entity.badgeConfig?.copy()
+        inboxConfig = entity.inboxConfig?.copy()
+        dismissedAt = entity.dismissedAt?.copy()
     }
 
     public override func isEqual(_ object: Any?) -> Bool {


### PR DESCRIPTION
### Description of Changes

CoreData objects should not be passed between threads. We ensure this by using the
private queue concurrency type on the managed object context, but we also map out
fields from the managed objects on to a data model.

These fields should be copied to ensure they remain available beyond the lifetime
of the NSManagedObject instance.

See: https://stackoverflow.com/q/13970807

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

Bump versions in:

-   [ ] `Sources/Kumulos.swift`
-   [ ] `KumulosSdkSwift.podspec`
-   [ ] `Sources/Info-*.plist`
-   [ ] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

