### PR TITLE
Fix inbox thread safety

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ Bump versions in:
 
 -   [ ] `Sources/Kumulos.swift`
 -   [ ] `KumulosSdkSwift.podspec`
+-   [ ] `KumulosSdkSwiftExtension.podspec`
 -   [ ] `Sources/Info-*.plist`
 -   [ ] `README.md`
 

--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -365,7 +365,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 7.0.0;
+				MARKETING_VERSION = 7.0.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -398,7 +398,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 7.0.0;
+				MARKETING_VERSION = 7.0.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -540,7 +540,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 7.0.0;
+				MARKETING_VERSION = 7.0.1;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -568,7 +568,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 7.0.0;
+				MARKETING_VERSION = 7.0.1;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "7.0.0"
+  s.version = "7.0.1"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "7.0.0"
+  s.version = "7.0.1"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -60,7 +60,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
     
-    internal let sdkVersion : String = "7.0.0"
+    internal let sdkVersion : String = "7.0.1"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/KumulosInApp.swift
+++ b/Sources/KumulosInApp.swift
@@ -16,17 +16,19 @@ public class InAppInboxItem {
     internal(set) open var availableTo: Date?
     internal(set) open var dismissedAt : Date?
     
-     init(entity: InAppMessageEntity) {
-        id = entity.id
-        
-        let inboxConfig = entity.inboxConfig as! [String:Any]
+    init(entity: InAppMessageEntity) {
+        id = Int64(entity.id)
+
+        let inboxConfig = entity.inboxConfig?.copy() as! [String:Any]
+
         title = inboxConfig["title"] as! String
         subtitle = inboxConfig["subtitle"] as! String
-        availableFrom = entity.inboxFrom as Date?
-        availableTo = entity.inboxTo as Date?
-        dismissedAt  = entity.dismissedAt as Date?
-   }
-    
+
+        availableFrom = entity.inboxFrom?.copy() as? Date
+        availableTo = entity.inboxTo?.copy() as? Date
+        dismissedAt = entity.dismissedAt?.copy() as? Date
+    }
+
     public func isAvailable() -> Bool {
         if (self.availableFrom != nil && self.availableFrom!.timeIntervalSinceNow > 0) {
             return false;


### PR DESCRIPTION
### Description of Changes

Fix thread safety by copying properties from the entity into inbox items before returning them.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Sources/Info-*.plist`
-   [ ] ~~`README.md`~~

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

