### PR TITLE
Allow handling local notifications with your own delegate

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -369,7 +369,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.0.0;
+				MARKETING_VERSION = 8.1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -402,7 +402,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.0.0;
+				MARKETING_VERSION = 8.1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -544,7 +544,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.0.0;
+				MARKETING_VERSION = 8.1.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -572,7 +572,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.0.0;
+				MARKETING_VERSION = 8.1.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.0.0"
+  s.version = "8.1.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.0.0"
+  s.version = "8.1.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 8.0'
+pod 'KumulosSdkSwift', '~> 8.1'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 8.0
+github "Kumulos/KumulosSdkSwift" ~> 8.1
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/KSUserNotificationCenterDelegate.swift
+++ b/Sources/KSUserNotificationCenterDelegate.swift
@@ -10,25 +10,66 @@ import UserNotifications
 
 class KSUserNotificationCenterDelegate : NSObject, UNUserNotificationCenterDelegate {
 
+    let existingDelegate: UNUserNotificationCenterDelegate?
+
+    override init() {
+        self.existingDelegate = UNUserNotificationCenter.current().delegate
+    }
+
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        if (Kumulos.sharedInstance.config.pushReceivedInForegroundHandlerBlock != nil) {
-            let push = KSPushNotification.init(userInfo: notification.request.content.userInfo, response: nil)
-            Kumulos.sharedInstance.config.pushReceivedInForegroundHandlerBlock?(push, completionHandler);
+        let push = KSPushNotification.init(userInfo: notification.request.content.userInfo, response: nil)
+
+        if push.id == 0 {
+            chainCenter(center, willPresent: notification, with: completionHandler)
+            return
         }
-        else {
+
+        if (Kumulos.sharedInstance.config.pushReceivedInForegroundHandlerBlock == nil) {
             completionHandler(.alert)
-       }
+            return
+        }
+
+        Kumulos.sharedInstance.config.pushReceivedInForegroundHandlerBlock?(push, completionHandler)
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        let userInfo = response.notification.request.content.userInfo
+
+        if userInfo["aps"] == nil {
+            chainCenter(center, didReceive: response, with: completionHandler)
+            return
+        }
+
         if (response.actionIdentifier == UNNotificationDismissActionIdentifier) {
             completionHandler()
             return
         }
 
-        let userInfo = response.notification.request.content.userInfo
-        Kumulos.sharedInstance.pushHandleOpen(withUserInfo: userInfo, response: response)
+        let handled = Kumulos.sharedInstance.pushHandleOpen(withUserInfo: userInfo, response: response)
+
+        if (!handled) {
+            chainCenter(center, didReceive: response, with: completionHandler)
+            return
+        }
 
         completionHandler()
+    }
+
+    fileprivate func chainCenter(_ center: UNUserNotificationCenter, willPresent notification : UNNotification, with completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        if self.existingDelegate != nil && self.existingDelegate?.responds(to: #selector(userNotificationCenter(_:willPresent:withCompletionHandler:))) == true {
+            self.existingDelegate?.userNotificationCenter?(center, willPresent: notification, withCompletionHandler: completionHandler)
+            return
+        }
+
+        completionHandler(.alert)
+    }
+
+    fileprivate func chainCenter(_ center:UNUserNotificationCenter, didReceive notificationResponse:UNNotificationResponse, with completionHandler: @escaping () -> Void) {
+        if self.existingDelegate != nil && self.existingDelegate?.responds(to: #selector(userNotificationCenter(_:didReceive:withCompletionHandler:))) == true {
+            self.existingDelegate?.userNotificationCenter?(center, didReceive: notificationResponse, withCompletionHandler: completionHandler)
+            return
+        }
+
+        completionHandler();
     }
 }

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -59,7 +59,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
     
-    internal let sdkVersion : String = "8.0.0"
+    internal let sdkVersion : String = "8.1.0"
 
     var networkRequestsInProgress = 0
 


### PR DESCRIPTION
### Description of Changes

Follows https://github.com/Kumulos/KumulosSdkObjectiveC/pull/42

Allow handling local notifications with your own implementation of `UNUserNotificationCenterDelegate`.

The delegate must be set as the current notification center delegate prior to initializing Kumulos.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods
