### PR TITLE
Minor in-app bugfixes

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -369,7 +369,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.0;
+				MARKETING_VERSION = 8.2.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -402,7 +402,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.0;
+				MARKETING_VERSION = 8.2.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -544,7 +544,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.0;
+				MARKETING_VERSION = 8.2.1;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -572,7 +572,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.0;
+				MARKETING_VERSION = 8.2.1;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.2.0"
+  s.version = "8.2.1"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.2.0"
+  s.version = "8.2.1"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/Sources/InApp/InAppHelper.swift
+++ b/Sources/InApp/InAppHelper.swift
@@ -565,10 +565,19 @@ internal class InAppHelper {
             defer { objc_sync_exit(self.pendingTickleIds) }
             
             self.pendingTickleIds.add(inAppPartId)
-       
-            let messagesToPresent = self.getMessagesToPresent([])
-            self.presenter.queueMessagesForPresentation(messages: messagesToPresent, tickleIds: self.pendingTickleIds)
 
+            let messagesToPresent = self.getMessagesToPresent([])
+
+            let tickleMessageFound = messagesToPresent.contains(where: { (message) -> Bool in
+                return message.id == inAppPartId
+            })
+
+            if (!tickleMessageFound) {
+                self.sync()
+                return
+            }
+
+            self.presenter.queueMessagesForPresentation(messages: messagesToPresent, tickleIds: self.pendingTickleIds)
         })
     }
     

--- a/Sources/InApp/InAppHelper.swift
+++ b/Sources/InApp/InAppHelper.swift
@@ -265,8 +265,9 @@ internal class InAppHelper {
                     after = "?after=\(self.urlEncode(url: formatter.string(from: lastSyncTime as Date))!)" ;
                 }
             }
-            
-            let path = "/v1/users/\(Kumulos.currentUserIdentifier)/messages\(after)"
+
+            let encodedIdentifier = self.urlEncode(url: Kumulos.currentUserIdentifier)
+            let path = "/v1/users/\(encodedIdentifier!)/messages\(after)"
         
             Kumulos.sharedInstance.pushHttpClient.sendRequest(.GET, toPath: path, data: nil, onSuccess: { response, decodedBody in
                 let messagesToPersist = decodedBody as? [[AnyHashable : Any]]

--- a/Sources/Kumulos+Analytics.swift
+++ b/Sources/Kumulos+Analytics.swift
@@ -91,13 +91,10 @@ public extension Kumulos {
         userIdLock.wait()
         UserDefaults.standard.removeObject(forKey: USER_ID_KEY)
         userIdLock.signal()
-        
-        
-        #if os(iOS)
+
         if (currentUserId != nil && currentUserId != Kumulos.installId) {
             getInstance().inAppHelper.handleAssociatedUserChange();
         }
-        #endif
     }
 
     fileprivate static func associateUserWithInstallImpl(userIdentifier: String, attributes: [String:AnyObject]?) {
@@ -120,12 +117,10 @@ public extension Kumulos {
         userIdLock.signal()
 
         Kumulos.trackEvent(eventType: KumulosEvent.STATS_ASSOCIATE_USER, properties: params, immediateFlush: true)
-        
-        #if os(iOS)
-        if (currentUserId != nil && currentUserId != userIdentifier) {
+
+        if (currentUserId != nil || currentUserId != userIdentifier) {
             getInstance().inAppHelper.handleAssociatedUserChange();
         }
-        #endif
     }
     
 }

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -131,7 +131,11 @@ public extension Kumulos {
         let token = serializeDeviceToken(deviceToken)
         let iosTokenType = getTokenType()
 
-        let parameters = ["token" : token, "type" : sharedInstance.pushNotificationDeviceType, "iosTokenType" : iosTokenType] as [String : Any]
+        let bundleId = Bundle.main.infoDictionary!["CFBundleIdentifier"] as Any
+        let parameters = ["token" : token,
+                          "type" : sharedInstance.pushNotificationDeviceType,
+                          "iosTokenType" : iosTokenType,
+                          "bundleId": bundleId] as [String : Any]
         
         Kumulos.trackEvent(eventType: KumulosEvent.PUSH_DEVICE_REGISTER, properties: parameters as [String : AnyObject], immediateFlush: true)
     }

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -308,7 +308,7 @@ class PushHelper {
 
                 if result < 0 {
                     fetchResult = .failed
-                } else if result > 1 {
+                } else if result > 0 {
                     fetchResult = .newData
                 }
                 // No data case is default, allow override from other handler

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -60,7 +60,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
     
-    internal let sdkVersion : String = "8.2.0"
+    internal let sdkVersion : String = "8.2.1"
 
     var networkRequestsInProgress = 0
 


### PR DESCRIPTION
### Description of Changes

A few minor bug fixes related to in-app message handling:

- Fix in-app AutoEnroll consent strategy when changing users
- Url encode the user identifier in in-app sync path
- Add bundleId to token event
- Fix conditional for background fetch result
- Fix edge cases where in-app push notification doesn't show in-app

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [ ] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods
