### PR TITLE
Fix regression of in-app inbox handling when using user association

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -369,7 +369,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.2;
+				MARKETING_VERSION = 8.2.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -402,7 +402,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.2;
+				MARKETING_VERSION = 8.2.3;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -544,7 +544,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.2;
+				MARKETING_VERSION = 8.2.3;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -572,7 +572,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.2;
+				MARKETING_VERSION = 8.2.3;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.2.2"
+  s.version = "8.2.3"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.2.2"
+  s.version = "8.2.3"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/Sources/Kumulos+Analytics.swift
+++ b/Sources/Kumulos+Analytics.swift
@@ -118,7 +118,7 @@ public extension Kumulos {
 
         Kumulos.trackEvent(eventType: KumulosEvent.STATS_ASSOCIATE_USER, properties: params, immediateFlush: true)
 
-        if (currentUserId != nil || currentUserId != userIdentifier) {
+        if (currentUserId == nil || currentUserId != userIdentifier) {
             getInstance().inAppHelper.handleAssociatedUserChange();
         }
     }

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -60,7 +60,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
     
-    internal let sdkVersion : String = "8.2.2"
+    internal let sdkVersion : String = "8.2.3"
 
     var networkRequestsInProgress = 0
 


### PR DESCRIPTION
### Description of Changes

Fix regression introduced by previous PR #47 commit fixing a conditional in the user association change handler.

This (actually) fixes the conditional.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [ ] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

