### PR TITLE
Delete messages from inbox

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -369,7 +369,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.4;
+				MARKETING_VERSION = 8.3.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -402,7 +402,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.4;
+				MARKETING_VERSION = 8.3.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -544,7 +544,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.4;
+				MARKETING_VERSION = 8.3.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -572,7 +572,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.4;
+				MARKETING_VERSION = 8.3.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -369,7 +369,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.3;
+				MARKETING_VERSION = 8.2.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -402,7 +402,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.3;
+				MARKETING_VERSION = 8.2.4;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -544,7 +544,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.3;
+				MARKETING_VERSION = 8.2.4;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -572,7 +572,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.2.3;
+				MARKETING_VERSION = 8.2.4;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.2.3"
+  s.version = "8.2.4"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.2.4"
+  s.version = "8.3.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.2.4"
+  s.version = "8.3.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.2.3"
+  s.version = "8.2.4"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 8.2'
+pod 'KumulosSdkSwift', '~> 8.3'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 8.2
+github "Kumulos/KumulosSdkSwift" ~> 8.3
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/InApp/InAppHelper.swift
+++ b/Sources/InApp/InAppHelper.swift
@@ -311,12 +311,11 @@ internal class InAppHelper {
     }
     
     private func urlEncode(url: String) -> String? {
-        let unreserved = "*-._ "
+        let unreserved = "-._~"
         var allowed = CharacterSet.alphanumerics
         allowed.insert(charactersIn: unreserved)
-        
-        var encoded = url.addingPercentEncoding(withAllowedCharacters: allowed)
-        encoded = encoded?.replacingOccurrences(of: " ", with: "+")
+
+        let encoded = url.addingPercentEncoding(withAllowedCharacters: allowed)
         
         return encoded
     }

--- a/Sources/InApp/InAppHelper.swift
+++ b/Sources/InApp/InAppHelper.swift
@@ -356,7 +356,6 @@ internal class InAppHelper {
                 model.id = partId
                 model.updatedAt = dateParser.date(from: message["updatedAt"] as! String)! as NSDate
                 if (model.dismissedAt == nil){
-                    print("dismissedAt is nil, updating...");
                     model.dismissedAt =  dateParser.date(from: message["openedAt"] as? String ?? "") as NSDate?
                 }
                 model.presentedWhen = message["presentedWhen"] as! String
@@ -373,9 +372,8 @@ internal class InAppHelper {
                     model.inboxTo = dateParser.date(from: inbox["to"] as? String ?? "") as NSDate?
                 }
                 
-                let inboxDeletedAt = message["inboxDeletedAt"] as! String?
+                let inboxDeletedAt = message["inboxDeletedAt"] as? String
                 if (inboxDeletedAt != nil){
-                    print("inboxDeletedAt not nil");
                     model.inboxConfig = nil;
                     model.inboxFrom = nil;
                     model.inboxTo = nil;

--- a/Sources/InApp/InAppHelper.swift
+++ b/Sources/InApp/InAppHelper.swift
@@ -377,6 +377,9 @@ internal class InAppHelper {
                     model.inboxConfig = nil;
                     model.inboxFrom = nil;
                     model.inboxTo = nil;
+                    if (model.dismissedAt == nil){
+                        model.dismissedAt = dateParser.date(from: inboxDeletedAt!) as NSDate?
+                    }
                 }
                 
                 model.expiresAt = dateParser.date(from: message["expiresAt"] as? String ?? "") as NSDate?
@@ -614,12 +617,12 @@ internal class InAppHelper {
                 return;
             }
             
-            //setting inbox columns to nil turns this message into a message without inbox.
-            //it can still be displayed if wasn't open. It will be evicted like other messages without inbox
+            //setting inbox columns to nil and dismissedAt to now turns this message into a message to be evicted
             if (messageEntities.count == 1){
                 messageEntities[0].inboxTo = nil
                 messageEntities[0].inboxFrom = nil
                 messageEntities[0].inboxConfig = nil
+                messageEntities[0].dismissedAt = NSDate()
             }
             
             do{

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -61,7 +61,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
     
-    internal let sdkVersion : String = "8.2.4"
+    internal let sdkVersion : String = "8.3.0"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -29,6 +29,7 @@ internal enum KumulosEvent : String {
     case MESSAGE_OPENED = "k.message.opened"
     case MESSAGE_DISMISSED = "k.message.dismissed"
     case MESSAGE_DELIVERED = "k.message.delivered"
+    case MESSAGE_DELETED_FROM_INBOX = "k.message.inbox.deleted"
 }
 
 public typealias InAppDeepLinkHandlerBlock = ([AnyHashable:Any]) -> Void

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -61,7 +61,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
     
-    internal let sdkVersion : String = "8.2.3"
+    internal let sdkVersion : String = "8.2.4"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/KumulosInApp.swift
+++ b/Sources/KumulosInApp.swift
@@ -104,4 +104,8 @@ public class KumulosInApp {
         
         return result ? InAppMessagePresentationResult.PRESENTED : InAppMessagePresentationResult.FAILED 
     }
+    
+    public static func deleteMessageFromInbox(item: InAppInboxItem) -> Bool {
+        return Kumulos.sharedInstance.inAppHelper.deleteMessageFromInbox(withId: item.id)
+    }
 }


### PR DESCRIPTION
### Description of Changes

New public function `deleteMessageFromInbox(item: InAppInboxItem) -> Bool`. It sends `k.message.inbox.deleted` event and sets inbox columns to nil. This transforms the message into a message without inbox. Eviction/presentation rules of a message without inbox apply. 

Additionally, when saving messages
1) update dismissedAt only if it is currently nil
2) set inbox columns to nil if payload contains `inboxDeletedAt`

Additionally fix URL-encoding to conform to RFC 3986

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [ ] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

