### PR TITLE
Push permission prompting guards & authorization callback

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -369,7 +369,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.3.2;
+				MARKETING_VERSION = 8.3.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -402,7 +402,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.3.2;
+				MARKETING_VERSION = 8.3.3;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -544,7 +544,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.3.2;
+				MARKETING_VERSION = 8.3.3;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -572,7 +572,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.3.2;
+				MARKETING_VERSION = 8.3.3;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.3.2"
+  s.version = "8.3.3"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.3.2"
+  s.version = "8.3.3"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -123,7 +123,7 @@ public extension Kumulos {
         }
 
         let askPermission : () -> Void = {
-            if UIApplication.shared.applicationState != .active {
+            if UIApplication.shared.applicationState == .background {
                 onAuthorizationStatus?(.notDetermined,
                                        NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Application not active, aborting push permission request"]) as Error)
                 return
@@ -155,11 +155,7 @@ public extension Kumulos {
                 requestToken()
                 break
             default:
-                // Queue on the main thread to allow application state to settle
-                // If called during applicationDidLaunch, state is still inactive
-                DispatchQueue.main.async {
-                    askPermission()
-                }
+                askPermission()
                 break
             }
         }

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -123,25 +123,27 @@ public extension Kumulos {
         }
 
         let askPermission : () -> Void = {
-            if UIApplication.shared.applicationState == .background {
-                onAuthorizationStatus?(.notDetermined,
-                                       NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Application not active, aborting push permission request"]) as Error)
-                return
-            }
-
-            center.requestAuthorization(options: [.alert, .badge, .sound]) { (granted, error) in
-                if let err = error {
-                    onAuthorizationStatus?(.notDetermined, err)
+            DispatchQueue.main.async {
+                if UIApplication.shared.applicationState == .background {
+                    onAuthorizationStatus?(.notDetermined,
+                                           NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Application not active, aborting push permission request"]) as Error)
                     return
                 }
 
-                if (!granted) {
-                    onAuthorizationStatus?(.denied, nil)
-                    return
-                }
+                center.requestAuthorization(options: [.alert, .badge, .sound]) { (granted, error) in
+                    if let err = error {
+                        onAuthorizationStatus?(.notDetermined, err)
+                        return
+                    }
 
-                onAuthorizationStatus?(.authorized, nil)
-                requestToken()
+                    if (!granted) {
+                        onAuthorizationStatus?(.denied, nil)
+                        return
+                    }
+
+                    onAuthorizationStatus?(.authorized, nil)
+                    requestToken()
+                }
             }
         }
 

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -90,25 +90,30 @@ public extension Kumulos {
         On success will raise the didRegisterForRemoteNotificationsWithDeviceToken UIApplication event
     */
     static func pushRequestDeviceToken() {
-       if #available(iOS 10.0, *) {
-            let center = UNUserNotificationCenter.current()
-            center.requestAuthorization(options: [.alert, .badge, .sound]) { (granted, error) in
-                if (!granted || error != nil) {
-                    return
-                }
-
-                DispatchQueue.main.async {
-                    UIApplication.shared.registerForRemoteNotifications()
-                }
-            }
+        if #available(iOS 10.0, *) {
+            requestToken()
         } else {
             DispatchQueue.main.async {
                 requestTokenLegacy()
             }
         }
     }
+
+    @available(iOS 10.0, *)
+    fileprivate static func requestToken() {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .badge, .sound]) { (granted, error) in
+            if (!granted || error != nil) {
+                return
+            }
+
+            DispatchQueue.main.async {
+                UIApplication.shared.registerForRemoteNotifications()
+            }
+        }
+    }
         
-    private static func requestTokenLegacy() {
+    fileprivate static func requestTokenLegacy() {
          // Determine the type of notifications we want to ask permission for, for example we may want to alert the user, update the badge number and play a sound
          let notificationTypes: UIUserNotificationType = [UIUserNotificationType.alert, UIUserNotificationType.badge, UIUserNotificationType.sound]
 

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -61,7 +61,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
     
-    internal let sdkVersion : String = "8.3.2"
+    internal let sdkVersion : String = "8.3.3"
 
     var networkRequestsInProgress = 0
 


### PR DESCRIPTION
### Description of Changes

It has been observed on iOS 13.4 that push prompts can be shown (1) whilst the app is not
in the foreground, and (2), multiple times to the same user.

For (1), we guard asking permission with application status being active.

For (2), we attempt to determine existing authorization status prior to requesting authorization
again. It is unclear if this will help as `requestAuthorization` is already meant to only ask once
according to the Apple Developer Guide, so this pre-flight check seems unnecessary.

Relevant sections:

- https://developer.apple.com/documentation/usernotifications/asking_permission_to_use_notifications?language=objc
- https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649527-requestauthorizationwithoptions?language=objc
- https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649524-getnotificationsettingswithcompl?language=objc

In addition, add an optional closure to the `Kumulos.pushRequestDeviceToken()` method that will be invoked with the current determination of `UNAuthorizationStatus` or any error whilst requesting.

```swift
Kumulos.pushRequestDeviceToken { (status, err) in
    if err != nil {
        print(err ?? "No error description")
        return
    }

    switch status {
    case .authorized:
        // ...
        break
    case .denied:
        // ...
        break
    default:
        // ...
        break
    }
}
```

> Note that errors retrieving a token are separate to authorization, and should be handled with the `application:didFailToRegisterForRemoteNotificationsWithError:` delegate method.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

