### PR TITLE
Guard session finalisation forced unwrap exception

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -418,7 +418,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.4.1;
+				MARKETING_VERSION = 8.4.2;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -452,7 +452,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.4.1;
+				MARKETING_VERSION = 8.4.2;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -595,7 +595,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.4.1;
+				MARKETING_VERSION = 8.4.2;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -623,7 +623,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.4.1;
+				MARKETING_VERSION = 8.4.2;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.4.1"
+  s.version = "8.4.2"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.4.1"
+  s.version = "8.4.2"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -55,7 +55,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "8.4.1"
+    internal let sdkVersion : String = "8.4.2"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/SessionHelper.swift
+++ b/Sources/SessionHelper.swift
@@ -27,7 +27,6 @@ class SessionIdleTimer {
             }
             
             self.invalidationLock.signal()
-            
             helper.sessionDidEnd()
         }
     }
@@ -83,7 +82,7 @@ internal class SessionHelper {
         }
 
         if bgTask != UIBackgroundTaskIdentifier.invalid {
-            UIApplication.shared.endBackgroundTask(convertToUIBackgroundTaskIdentifier(bgTask.rawValue))
+            UIApplication.shared.endBackgroundTask(bgTask)
             bgTask = UIBackgroundTaskIdentifier.invalid
         }
     }
@@ -95,8 +94,8 @@ internal class SessionHelper {
     }
 
     @objc private func appBecameBackground() {
-        bgTask = UIApplication.shared.beginBackgroundTask(withName: "sync", expirationHandler: {
-            UIApplication.shared.endBackgroundTask(convertToUIBackgroundTaskIdentifier(self.bgTask.rawValue))
+        bgTask = UIApplication.shared.beginBackgroundTask(withName: "ksession", expirationHandler: {
+            UIApplication.shared.endBackgroundTask(self.bgTask)
             self.bgTask = UIBackgroundTaskIdentifier.invalid
         })
     }
@@ -116,17 +115,10 @@ internal class SessionHelper {
             self.becameInactiveAt = nil
 
             if self.bgTask != UIBackgroundTaskIdentifier.invalid {
-                let taskId = convertToUIBackgroundTaskIdentifier(self.bgTask.rawValue)
+                UIApplication.shared.endBackgroundTask(self.bgTask)
                 self.bgTask = UIBackgroundTaskIdentifier.invalid
-                UIApplication.shared.endBackgroundTask(taskId)
             }
         })
     }
     
 }
-
-// Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertToUIBackgroundTaskIdentifier(_ input: Int) -> UIBackgroundTaskIdentifier {
-    return UIBackgroundTaskIdentifier(rawValue: input)
-}
-

--- a/Sources/SessionHelper.swift
+++ b/Sources/SessionHelper.swift
@@ -117,10 +117,14 @@ internal class SessionHelper {
     }
 
     fileprivate func sessionDidEnd() {
+        guard let sessionEndTime = becameInactiveAt else {
+            return
+        }
+
         startNewSession = true
         sessionIdleTimer = nil
 
-        Kumulos.trackEvent(eventType: KumulosEvent.STATS_BACKGROUND.rawValue, atTime: becameInactiveAt!, properties: nil, immediateFlush: true, onSyncComplete: {err in
+        Kumulos.trackEvent(eventType: KumulosEvent.STATS_BACKGROUND.rawValue, atTime: sessionEndTime, properties: nil, immediateFlush: true, onSyncComplete: {err in
             self.becameInactiveAt = nil
 
             if self.bgTask != UIBackgroundTaskIdentifier.invalid {

--- a/Sources/SessionHelper.swift
+++ b/Sources/SessionHelper.swift
@@ -44,6 +44,7 @@ internal class SessionHelper {
     private var sessionIdleTimer : SessionIdleTimer?
     private var bgTask : UIBackgroundTaskIdentifier
     private var sessionIdleTimeout : UInt
+    private let syncBarrier = DispatchSemaphore(value: 0)
     
     init(sessionIdleTimeout: UInt) {
         startNewSession = true
@@ -118,7 +119,11 @@ internal class SessionHelper {
                 UIApplication.shared.endBackgroundTask(self.bgTask)
                 self.bgTask = UIBackgroundTaskIdentifier.invalid
             }
+
+            self.syncBarrier.signal()
         })
+
+        _ = syncBarrier.wait(timeout: .now() + .seconds(10))
     }
     
 }

--- a/Sources/SessionHelper.swift
+++ b/Sources/SessionHelper.swift
@@ -99,12 +99,20 @@ internal class SessionHelper {
             UIApplication.shared.endBackgroundTask(self.bgTask)
             self.bgTask = UIBackgroundTaskIdentifier.invalid
         })
+
+        if becameInactiveAt == nil {
+            becameInactiveAt = Date()
+        }
     }
 
     @objc private func appWillTerminate() {
         if sessionIdleTimer != nil {
             sessionIdleTimer?.invalidate()
             sessionDidEnd()
+        }
+
+        if becameInactiveAt == nil {
+            becameInactiveAt = Date()
         }
     }
 


### PR DESCRIPTION
### Description of Changes

Under certain circumstances it seems possible the `becameInactiveAt` field of the `SessionHelper` can be `nil` when `sessionDidEnd` is invoked. In these cases, the forced unwrap of `becameInactiveAt` can cause an exception.

Whilst it has not been possible to reliably reproduce the root cause, these changes introduce hardening against the error by:

- Setting `becameInactiveAt` from all background/termination lifecycle delegates if it was still `nil`
- Guarding use of `becameInactiveAt` in `sessionDidEnd` and aborting if it was `nil`

In addition, minor refactoring was undertaken to:

- Tidy up use of background task identifiers (Swift 4.2 conversion helper seems redundant now)
- Block the main thread whilst syncing events in `sessionDidEnd` to help ensure we get events when `appWillTerminate` is the cause of session finalisation

Follow-up explorations around this issue may consider:

-  The application scene lifecycle delegates and their potential role here in apps using UIScene
- Thread synchronisation / invocations for lifecycle observers and session invalidation callbacks

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

