### PR TITLE
Guard unwrapping data from APNS payloads incases where notifications are received from a non-Kumulos APNS sender

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -418,7 +418,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.4.3;
+				MARKETING_VERSION = 8.4.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -452,7 +452,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.4.3;
+				MARKETING_VERSION = 8.4.4;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.4.3"
+  s.version = "8.4.4"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.4.3"
+  s.version = "8.4.4"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/Sources/InApp/InAppPresenter.swift
+++ b/Sources/InApp/InAppPresenter.swift
@@ -311,8 +311,8 @@ class InAppPresenter : NSObject, WKScriptMessageHandler, WKNavigationDelegate{
            return;
        }
         
-        var body = message.body as! NSDictionary
-        var type = body["type"] as! String
+        let body = message.body as! NSDictionary
+        let type = body["type"] as! String
         
         if (type == "READY") {
               messageQueueLock.wait()

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -55,7 +55,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "8.4.3"
+    internal let sdkVersion : String = "8.4.4"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/Shared/KumulosHelper.swift
+++ b/Sources/Shared/KumulosHelper.swift
@@ -55,11 +55,15 @@ internal class KumulosHelper {
     }
     
     static func getBadgeFromUserInfo(userInfo: [AnyHashable:Any]) -> NSNumber? {
-        let custom = userInfo["custom"] as! [AnyHashable:Any]
-        let aps = userInfo["aps"] as! [AnyHashable:Any]
+        let custom = userInfo["custom"] as? [AnyHashable:Any]
+        let aps = userInfo["aps"] as? [AnyHashable:Any]
         
-        let incrementBy: NSNumber? = custom["badge_inc"] as? NSNumber
-        let badge: NSNumber? = aps["badge"] as? NSNumber
+        if (custom == nil || aps == nil) {
+            return nil
+        }
+        
+        let incrementBy: NSNumber? = custom!["badge_inc"] as? NSNumber
+        let badge: NSNumber? = aps!["badge"] as? NSNumber
         
         if (badge == nil){
             return nil


### PR DESCRIPTION
### Description of Changes

Guarded unwrapping of the UserInfo payload from an APNS message.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

