### PR TITLE
Delivery receipt refactor

### DIFF
--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -34,9 +34,7 @@ public class KumulosNotificationService {
             addButtons(messageId: id, bestAttemptContent: bestAttemptContent, buttons: buttons!)
         }
         
-        let dispatchQueue = DispatchQueue(label: "com.kumulos.notifications", qos: .userInitiated, attributes: .concurrent)
         let dispatchGroup = DispatchGroup()
-        
         
         dispatchGroup.enter()
         

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -118,10 +118,11 @@ public class KumulosNotificationService {
         dispatchGroup.enter()
  
         loadAttachment(url!, withExtension: picExtension, completionHandler: { attachment in
-           if attachment != nil {
+            if attachment != nil {
                bestAttemptContent.attachments = [attachment!]
-                dispatchGroup.leave()
-           }
+
+            }
+            dispatchGroup.leave()
         })
     }
     

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -226,7 +226,6 @@ public class KumulosNotificationService {
         
         analyticsHelper.trackEvent(eventType: KumulosSharedEvent.MESSAGE_DELIVERED.rawValue, atTime: Date(), properties: props, immediateFlush: true, onSyncComplete: {err in
             self.syncBarrier.signal()
-            dispatchGroup.leave()
         })
 
         _ = syncBarrier.wait(timeout: .now() + .seconds(10))

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -209,7 +209,7 @@ public class KumulosNotificationService {
         KeyValPersistenceHelper.set(newBadge, forKey: KumulosUserDefaultsKey.BADGE_COUNT.rawValue)
     }
 
-    fileprivate class func trackDeliveredEvent(dispatchGroup: DispatchGroup, userInfo: [AnyHashable:Any], notificationId: Int) {
+    fileprivate static func trackDeliveredEvent(dispatchGroup: DispatchGroup, userInfo: [AnyHashable:Any], notificationId: Int) {
         let aps = userInfo["aps"] as! [AnyHashable:Any]
         if let contentAvailable = aps["content-available"] as? Int, contentAvailable == 1 {
             return

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -229,6 +229,7 @@ public class KumulosNotificationService {
         })
 
         _ = syncBarrier.wait(timeout: .now() + .seconds(10))
+        dispatchGroup.leave()
     }
     
     fileprivate static func initializeAnalyticsHelper() {

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -209,7 +209,7 @@ public class KumulosNotificationService {
         KeyValPersistenceHelper.set(newBadge, forKey: KumulosUserDefaultsKey.BADGE_COUNT.rawValue)
     }
 
-    fileprivate static func trackDeliveredEvent(dispatchGroup: DispatchGroup, userInfo: [AnyHashable:Any], notificationId: Int) {
+    fileprivate class func trackDeliveredEvent(dispatchGroup: DispatchGroup, userInfo: [AnyHashable:Any], notificationId: Int) {
         let aps = userInfo["aps"] as! [AnyHashable:Any]
         if let contentAvailable = aps["content-available"] as? Int, contentAvailable == 1 {
             return
@@ -232,7 +232,7 @@ public class KumulosNotificationService {
         dispatchGroup.leave()
     }
     
-    fileprivate static func initializeAnalyticsHelper() {
+    fileprivate class func initializeAnalyticsHelper() {
         let apiKey = KeyValPersistenceHelper.object(forKey: KumulosUserDefaultsKey.API_KEY.rawValue) as! String?
         let secretKey = KeyValPersistenceHelper.object(forKey: KumulosUserDefaultsKey.SECRET_KEY.rawValue) as! String?
         if (apiKey == nil || secretKey == nil){


### PR DESCRIPTION
### Description of Changes

Improve reliability of the delivery receipt networking in the Notification Service Extension, use a dispatch group to handle marshalling the async complete of optional image load and delivery receipt. Delivery tracking has also been made a blocking process with a 10 second timeout.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [ ] `Sources/Kumulos.swift`
-   [ ] `KumulosSdkSwift.podspec`
-   [ ] `KumulosSdkSwiftExtension.podspec`
-   [ ] `Build target version for plist`
-   [ ] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

