### PR TITLE
Bugfix: DateFormatter is not parsing dates on some devices

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -426,7 +426,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.7.0;
+				MARKETING_VERSION = 8.7.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -460,7 +460,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.7.0;
+				MARKETING_VERSION = 8.7.1;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -603,7 +603,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.7.0;
+				MARKETING_VERSION = 8.7.1;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -631,7 +631,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.7.0;
+				MARKETING_VERSION = 8.7.1;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.7.0"
+  s.version = "8.7.1"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.7.0"
+  s.version = "8.7.1"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/Sources/InApp/InAppHelper.swift
+++ b/Sources/InApp/InAppHelper.swift
@@ -260,6 +260,7 @@ internal class InAppHelper {
                 formatter.timeStyle = .full
                 formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
                 formatter.timeZone = NSTimeZone(forSecondsFromGMT: 0) as TimeZone
+                formatter.locale = Locale(identifier: "en_US_POSIX")
                 if let lastSyncTime = lastSyncTime {
                     after = "?after=\(KSHttpUtil.urlEncode(formatter.string(from: lastSyncTime as Date))!)" ;
                 }
@@ -322,7 +323,8 @@ internal class InAppHelper {
             var lastSyncTime = NSDate(timeIntervalSince1970: 0)
             let dateParser = DateFormatter()
             dateParser.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-            dateParser.timeZone = NSTimeZone(forSecondsFromGMT: 0) as TimeZone
+            dateParser.locale = Locale(identifier: "en_US_POSIX")
+            dateParser.timeZone = TimeZone(secondsFromGMT: 0)
             
             for message in messages {
                 let partId = message["id"] as! Int64

--- a/Sources/InApp/InAppHelper.swift
+++ b/Sources/InApp/InAppHelper.swift
@@ -322,6 +322,7 @@ internal class InAppHelper {
             var lastSyncTime = NSDate(timeIntervalSince1970: 0)
             let dateParser = DateFormatter()
             dateParser.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+            dateParser.timeZone = NSTimeZone(forSecondsFromGMT: 0) as TimeZone
             
             for message in messages {
                 let partId = message["id"] as! Int64

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -58,7 +58,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "8.7.0"
+    internal let sdkVersion : String = "8.7.1"
 
     var networkRequestsInProgress = 0
 


### PR DESCRIPTION
### Description of Changes

Bugfix for a rare crash on this line `model.updatedAt = dateParser.date(from: message["updatedAt"] as! String)! as NSDate`. Upon investigation looks like API returns correctly formatted date, but DateFormatter on some devices is not able to parse it. The reason is default timezone/locale -- user can set them to something 'special' and then formatter cannot parse correctly. Need to explicitly set timezone and locale on the formatter when working with fixed format date representations. 

Sources:
1) [https://developer.apple.com/documentation/foundation/dateformatter#overview](https://developer.apple.com/documentation/foundation/dateformatter#overview) (docs)
2) [https://developer.apple.com/library/archive/qa/qa1480/_index.html](https://developer.apple.com/library/archive/qa/qa1480/_index.html)  (exactly the problem with examples when could happen)

Verified crash if change to 12h format via `Settings > General > Date & Time > 24-Hour Time` and then try to parse `2017-03-26T18:53:31+00:00`

Not using ISO8601DateFormatter to support older versions of iOS. Searched for other places where this might be relevant -- updated in 1. Formatter is initialised correctly in `KumulosCheckins.swift`.

TODO:
1) probably same problem for ObjC

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

