### PR TITLE
Track notification dismissed events

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -426,7 +426,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.7.1;
+				MARKETING_VERSION = 8.8.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -460,7 +460,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.7.1;
+				MARKETING_VERSION = 8.8.0;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -603,7 +603,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.7.1;
+				MARKETING_VERSION = 8.8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -631,7 +631,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.7.1;
+				MARKETING_VERSION = 8.8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -49,6 +49,10 @@
 		B62FB8AB24244EFE0070A79D /* AppGroupsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62FB8972423997E0070A79D /* AppGroupsHelper.swift */; };
 		B62FB8AF242461C70070A79D /* AnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1293720A2006378D00EBC8F4 /* AnalyticsHelper.swift */; };
 		B62FB8B02424622F0070A79D /* KSHttp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123D90A722A160CF004B8392 /* KSHttp.swift */; };
+		B659805625F7CE98008C074D /* PendingNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B659805525F7CE98008C074D /* PendingNotification.swift */; };
+		B659805725F7CE98008C074D /* PendingNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B659805525F7CE98008C074D /* PendingNotification.swift */; };
+		B659805D25F81F5C008C074D /* PendingNotificationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B659805C25F81F5C008C074D /* PendingNotificationHelper.swift */; };
+		B659805E25F81F5C008C074D /* PendingNotificationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B659805C25F81F5C008C074D /* PendingNotificationHelper.swift */; };
 		B66094EE241BEADF005C3B34 /* KeyValPersistenceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66094ED241BEADF005C3B34 /* KeyValPersistenceHelper.swift */; };
 		B6E48F5F2425057E00E8B3B9 /* SessionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E48F5E2425057E00E8B3B9 /* SessionHelper.swift */; };
 		B6E48F64242BA8D700E8B3B9 /* KSBadgeObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = B6E48F63242BA8D700E8B3B9 /* KSBadgeObserver.m */; };
@@ -99,6 +103,8 @@
 		B62FB894242384020070A79D /* KumulosUserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KumulosUserDefaultsKey.swift; sourceTree = "<group>"; };
 		B62FB8972423997E0070A79D /* AppGroupsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupsHelper.swift; sourceTree = "<group>"; };
 		B62FB8A5242448520070A79D /* KumulosHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KumulosHelper.swift; path = Sources/Shared/KumulosHelper.swift; sourceTree = SOURCE_ROOT; };
+		B659805525F7CE98008C074D /* PendingNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingNotification.swift; sourceTree = "<group>"; };
+		B659805C25F81F5C008C074D /* PendingNotificationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingNotificationHelper.swift; sourceTree = "<group>"; };
 		B66094ED241BEADF005C3B34 /* KeyValPersistenceHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValPersistenceHelper.swift; sourceTree = "<group>"; };
 		B6E48F5E2425057E00E8B3B9 /* SessionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SessionHelper.swift; path = Sources/SessionHelper.swift; sourceTree = "<group>"; };
 		B6E48F63242BA8D700E8B3B9 /* KSBadgeObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = KSBadgeObserver.m; path = Sources/KSBadgeObserver.m; sourceTree = "<group>"; };
@@ -211,6 +217,8 @@
 				B66094ED241BEADF005C3B34 /* KeyValPersistenceHelper.swift */,
 				B62FB894242384020070A79D /* KumulosUserDefaultsKey.swift */,
 				B62FB8972423997E0070A79D /* AppGroupsHelper.swift */,
+				B659805525F7CE98008C074D /* PendingNotification.swift */,
+				B659805C25F81F5C008C074D /* PendingNotificationHelper.swift */,
 			);
 			name = Shared;
 			path = Sources/Shared;
@@ -361,8 +369,10 @@
 				B62FB8A924244EF90070A79D /* KumulosHelper.swift in Sources */,
 				B62FB8B02424622F0070A79D /* KSHttp.swift in Sources */,
 				B62FB8AA24244EFC0070A79D /* KeyValPersistenceHelper.swift in Sources */,
+				B659805725F7CE98008C074D /* PendingNotification.swift in Sources */,
 				B62FB8AF242461C70070A79D /* AnalyticsHelper.swift in Sources */,
 				B62FB8AB24244EFE0070A79D /* AppGroupsHelper.swift in Sources */,
+				B659805E25F81F5C008C074D /* PendingNotificationHelper.swift in Sources */,
 				6F0EB56923D067F3007EDA84 /* CategoryHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -374,6 +384,7 @@
 				6F469D1C205BCE720069D788 /* Kumulos+Engage.swift in Sources */,
 				127B22E01D9BE59E00D9C94B /* Kumulos+Stats.swift in Sources */,
 				127B22D91D9BE59E00D9C94B /* CwlSysctl.swift in Sources */,
+				B659805625F7CE98008C074D /* PendingNotification.swift in Sources */,
 				127B22DF1D9BE59E00D9C94B /* Kumulos+Push.swift in Sources */,
 				B625D077233A7A18003AA551 /* InAppModels.swift in Sources */,
 				A13430A11F013D6E00D185FD /* Kumulos+Crash.swift in Sources */,
@@ -397,6 +408,7 @@
 				128EF6F0233B6FF6006C7A71 /* KSUserNotificationCenterDelegate.swift in Sources */,
 				6FDBD0EA233CF8C2000398EE /* KumulosInApp.swift in Sources */,
 				126F12632507EAB2007DBBE1 /* KumulosCheckins.swift in Sources */,
+				B659805D25F81F5C008C074D /* PendingNotificationHelper.swift in Sources */,
 				B62FB895242384020070A79D /* KumulosUserDefaultsKey.swift in Sources */,
 				B66094EE241BEADF005C3B34 /* KeyValPersistenceHelper.swift in Sources */,
 				1293720B2006378D00EBC8F4 /* AnalyticsHelper.swift in Sources */,

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.7.1"
+  s.version = "8.8.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.7.1"
+  s.version = "8.8.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 8.7'
+pod 'KumulosSdkSwift', '~> 8.8'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 8.7
+github "Kumulos/KumulosSdkSwift" ~> 8.8
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -40,10 +40,7 @@ public class KumulosNotificationService {
         if (AppGroupsHelper.isKumulosAppGroupDefined()){
             maybeSetBadge(bestAttemptContent: bestAttemptContent, userInfo: userInfo)
             trackDeliveredEvent(dispatchGroup: dispatchGroup, userInfo: userInfo, notificationId: id)
-            
-            if (!isBackgroundPush(userInfo: userInfo)){
-                PendingNotificationHelper.add(notification: PendingNotification(id: id, deliveredAt: Date(), identifier: request.identifier))
-            }
+            PendingNotificationHelper.add(notification: PendingNotification(id: id, deliveredAt: Date(), identifier: request.identifier))
         }
         
         dispatchGroup.notify(queue: .main) {
@@ -250,11 +247,10 @@ public class KumulosNotificationService {
     
     fileprivate class func isBackgroundPush(userInfo: [AnyHashable:Any]) -> Bool{
         let aps = userInfo["aps"] as! [AnyHashable:Any]
-        
         if let contentAvailable = aps["content-available"] as? Int, contentAvailable == 1 {
             return true
         }
-        
+
         return false
     }
 }

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -29,9 +29,11 @@ public class KumulosNotificationService {
         let msgData = msg["data"] as! [AnyHashable:Any]
         let id = msgData["id"] as! Int
         
-        let actionButtons = getButtons(userInfo: userInfo, bestAttemptContent:bestAttemptContent)
-        
-        addCategory(bestAttemptContent:bestAttemptContent, actionArray: actionButtons, id: id)
+        if(bestAttemptContent.categoryIdentifier == "") {
+            let actionButtons = getButtons(userInfo: userInfo, bestAttemptContent:bestAttemptContent)
+            
+            addCategory(bestAttemptContent:bestAttemptContent, actionArray: actionButtons, id: id)
+        }
         
         let dispatchGroup = DispatchGroup()
         
@@ -70,10 +72,6 @@ public class KumulosNotificationService {
     
     fileprivate class func getButtons(userInfo:[AnyHashable:Any], bestAttemptContent: UNMutableNotificationContent) -> NSMutableArray {
         let actionArray = NSMutableArray()
-        
-        if(bestAttemptContent.categoryIdentifier != "") {
-            return actionArray
-        }
         
         let custom = userInfo["custom"] as! [AnyHashable:Any]
         let data = custom["a"] as! [AnyHashable:Any]

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -42,7 +42,7 @@ public class KumulosNotificationService {
             trackDeliveredEvent(dispatchGroup: dispatchGroup, userInfo: userInfo, notificationId: id)
             
             if (!isBackgroundPush(userInfo: userInfo)){
-                PendingNotificationHelper.add(notification: PendingNotification(id: id, deliveredAt: Date()))
+                PendingNotificationHelper.add(notification: PendingNotification(id: id, deliveredAt: Date(), identifier: request.identifier))
             }
         }
         

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -29,7 +29,9 @@ public class KumulosNotificationService {
         let msgData = msg["data"] as! [AnyHashable:Any]
         let id = msgData["id"] as! Int
         
-        maybeAddButtons(userInfo: userInfo, bestAttemptContent:bestAttemptContent)
+        let actionButtons = getButtons(userInfo: userInfo, bestAttemptContent:bestAttemptContent)
+        
+        addCategory(bestAttemptContent:bestAttemptContent, actionArray: actionButtons, id: id)
         
         let dispatchGroup = DispatchGroup()
         
@@ -65,25 +67,21 @@ public class KumulosNotificationService {
         return true
     }
     
-    fileprivate class func maybeAddButtons(userInfo:[AnyHashable:Any], bestAttemptContent: UNMutableNotificationContent) {
+    fileprivate class func getButtons(userInfo:[AnyHashable:Any], bestAttemptContent: UNMutableNotificationContent) -> NSMutableArray {
+        let actionArray = NSMutableArray()
+        
         if(bestAttemptContent.categoryIdentifier != "") {
-            return
+            return actionArray
         }
         
         let custom = userInfo["custom"] as! [AnyHashable:Any]
         let data = custom["a"] as! [AnyHashable:Any]
         
-        let msg = data["k.message"] as! [AnyHashable:Any]
-        let msgData = msg["data"] as! [AnyHashable:Any]
-        let id = msgData["id"] as! Int
-        
         let buttons = data["k.buttons"] as? NSArray
         
         if (buttons == nil || buttons!.count == 0) {
-            return;
+            return actionArray;
         }
-        
-        let actionArray = NSMutableArray()
         
         for button in buttons! {
             let buttonDict = button as! [AnyHashable:Any]
@@ -95,6 +93,10 @@ public class KumulosNotificationService {
             actionArray.add(action);
         }
         
+        return actionArray;
+    }
+    
+    fileprivate class func addCategory(bestAttemptContent: UNMutableNotificationContent, actionArray:NSMutableArray, id: Int) {
         let categoryIdentifier = CategoryHelper.getCategoryIdForMessageId(messageId: id)
         
         let category = UNNotificationCategory(identifier: categoryIdentifier, actions: actionArray as! [UNNotificationAction], intentIdentifiers: [],  options: .customDismissAction)

--- a/Sources/InApp/InAppHelper.swift
+++ b/Sources/InApp/InAppHelper.swift
@@ -407,6 +407,7 @@ internal class InAppHelper {
         if #available(iOS 10, *) {
            let tickleNotificationId = "k-in-app-message:\(id)"
            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [tickleNotificationId])
+           PendingNotificationHelper.remove(identifier: tickleNotificationId)
         }
     }
     

--- a/Sources/InApp/InAppPresenter.swift
+++ b/Sources/InApp/InAppPresenter.swift
@@ -130,6 +130,8 @@ class InAppPresenter : NSObject, WKScriptMessageHandler, WKNavigationDelegate{
         if #available(iOS 10, *) {
             let tickleNotificationId = "k-in-app-message:\(message.id)"
             UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [tickleNotificationId])
+            
+            PendingNotificationHelper.remove(identifier: tickleNotificationId)
         }
         
         messageQueueLock.wait()

--- a/Sources/KSUserNotificationCenterDelegate.swift
+++ b/Sources/KSUserNotificationCenterDelegate.swift
@@ -42,6 +42,12 @@ class KSUserNotificationCenterDelegate : NSObject, UNUserNotificationCenterDeleg
         }
 
         if (response.actionIdentifier == UNNotificationDismissActionIdentifier) {
+            let handled = Kumulos.sharedInstance.pushHandleDismissed(withUserInfo: userInfo, response: response)
+            if (!handled) {
+                chainCenter(center, didReceive: response, with: completionHandler)
+                return
+            }
+            
             completionHandler()
             return
         }

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -299,10 +299,10 @@ public extension Kumulos {
         let params = ["type": KS_MESSAGE_TYPE_PUSH, "id": notificationId]
               
         if let unwrappedDismissedAt = dismissedAt {
-            Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_DISMISSED.rawValue, atTime: unwrappedDismissedAt, properties:params, immediateFlush: true)
+            Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_DISMISSED.rawValue, atTime: unwrappedDismissedAt, properties:params)
         }
         else{
-            Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_DISMISSED, properties:params, immediateFlush: true)
+            Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_DISMISSED, properties:params)
         }
     }
     

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -226,6 +226,16 @@ public extension Kumulos {
         let params = ["type": KS_MESSAGE_TYPE_PUSH, "id": notification.id]
         Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_DISMISSED, properties:params)
     }
+    
+    internal func pushHandleOpen(withUserInfo: [AnyHashable: Any]?) {
+        guard let userInfo = withUserInfo else {
+            return
+        }
+
+        let notification = KSPushNotification(userInfo: userInfo)
+
+        self.pushHandleOpen(notification: notification)
+    }
   
     @available(iOS 10.0, *)
     internal func pushHandleOpen(withUserInfo: [AnyHashable: Any]?, response: UNNotificationResponse?) -> Bool {
@@ -366,6 +376,14 @@ class PushHelper {
                 })
             } else {
                 fetchBarrier.signal()
+            }
+            
+            if UIApplication.shared.applicationState == .inactive {
+               if #available(iOS 10, *) {
+                   // Noop (tap handler in delegate will deal with opening the URL)
+               } else {
+                   Kumulos.sharedInstance.pushHandleOpen(withUserInfo:userInfo)
+               }
             }
             
             let aps = userInfo["aps"] as! [AnyHashable:Any]

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -218,13 +218,7 @@ public extension Kumulos {
         Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_OPENED, properties:params)
     }
     
-    /**
-        Track a user dismissing a push notification
-
-        Parameters:
-            - notification: The notification which was dismissed
-    */
-    static func pushTrackDismissed(notification: KSPushNotification?) {
+    private func pushTrackDismissed(notification: KSPushNotification?) {
         guard let notification = notification else {
             return
         }
@@ -233,7 +227,6 @@ public extension Kumulos {
         Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_DISMISSED, properties:params)
     }
   
-    
     @available(iOS 10.0, *)
     internal func pushHandleOpen(withUserInfo: [AnyHashable: Any]?, response: UNNotificationResponse?) -> Bool {
         let notification = KSPushNotification(userInfo: withUserInfo, response: response)
@@ -281,7 +274,7 @@ public extension Kumulos {
             return false
         }
 
-        Kumulos.pushTrackDismissed(notification: notification)
+        self.pushTrackDismissed(notification: notification)
 
         return true
     }

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -224,7 +224,7 @@ public extension Kumulos {
         }
 
         let params = ["type": KS_MESSAGE_TYPE_PUSH, "id": notification.id]
-        Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_DISMISSED, properties:params)
+        Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_DISMISSED, properties:params, immediateFlush: true)
     }
     
     internal func pushHandleOpen(withUserInfo: [AnyHashable: Any]?) {

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -217,18 +217,23 @@ public extension Kumulos {
         let params = ["type": KS_MESSAGE_TYPE_PUSH, "id": notification.id]
         Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_OPENED, properties:params)
     }
+    
+    /**
+        Track a user dismissing a push notification
 
-    internal func pushHandleOpen(withUserInfo: [AnyHashable: Any]?) {
-        guard let userInfo = withUserInfo else {
+        Parameters:
+            - notification: The notification which was dismissed
+    */
+    static func pushTrackDismissed(notification: KSPushNotification?) {
+        guard let notification = notification else {
             return
         }
 
-        let notification = KSPushNotification(userInfo: userInfo)
-        
-        self.pushHandleOpen(notification: notification)
+        let params = ["type": KS_MESSAGE_TYPE_PUSH, "id": notification.id]
+        Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_DISMISSED, properties:params)
     }
   
-
+    
     @available(iOS 10.0, *)
     internal func pushHandleOpen(withUserInfo: [AnyHashable: Any]?, response: UNNotificationResponse?) -> Bool {
         let notification = KSPushNotification(userInfo: withUserInfo, response: response)
@@ -266,6 +271,19 @@ public extension Kumulos {
                userOpenedHandler(notification)
            }
        }
+    }
+    
+    @available(iOS 10.0, *)
+    internal func pushHandleDismissed(withUserInfo: [AnyHashable: Any]?, response: UNNotificationResponse?) -> Bool {
+        let notification = KSPushNotification(userInfo: withUserInfo, response: response)
+
+        if notification.id == 0 {
+            return false
+        }
+
+        Kumulos.pushTrackDismissed(notification: notification)
+
+        return true
     }
 
     fileprivate static func serializeDeviceToken(_ deviceToken: Data) -> String {

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -319,7 +319,6 @@ public extension Kumulos {
                 
                 actualPendingNotificationIds.append(notification.id)
             }
-            //dump(actualPendingNotificationIds)
             
             //TODO: how open vs maybeTrack order interact?
             

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -240,9 +240,7 @@ public extension Kumulos {
 
         self.pushHandleOpen(notification: notification)
         
-        if (AppGroupsHelper.isKumulosAppGroupDefined()){
-            PendingNotificationHelper.remove(id: notification.id)
-        }
+        PendingNotificationHelper.remove(id: notification.id)
        
         return true
     }
@@ -289,9 +287,7 @@ public extension Kumulos {
     
     @available(iOS 10.0, *)
     private func pushHandleDismissed(notificationId: Int, dismissedAt: Date? = nil) {
-        if (AppGroupsHelper.isKumulosAppGroupDefined()){
-            PendingNotificationHelper.remove(id: notificationId)
-        }
+        PendingNotificationHelper.remove(id: notificationId)
         self.pushTrackDismissed(notificationId: notificationId, dismissedAt: dismissedAt)
     }
     

--- a/Sources/Kumulos+Push.swift
+++ b/Sources/Kumulos+Push.swift
@@ -226,6 +226,9 @@ public extension Kumulos {
         }
 
         let notification = KSPushNotification(userInfo: userInfo)
+        if notification.id == 0 {
+            return
+        }
 
         self.pushHandleOpen(notification: notification)
     }
@@ -309,8 +312,8 @@ public extension Kumulos {
             return;
         }
         
-        var actualPendingNotificationIds: [Int] = []
         UNUserNotificationCenter.current().getDeliveredNotifications { (notifications: [UNNotification]) in
+            var actualPendingNotificationIds: [Int] = []
             for notification in notifications {
                 let notification = KSPushNotification(userInfo: notification.request.content.userInfo)
                 if (notification.id == 0){
@@ -319,8 +322,6 @@ public extension Kumulos {
                 
                 actualPendingNotificationIds.append(notification.id)
             }
-            
-            //TODO: how open vs maybeTrack order interact?
             
             let recordedPendingNotifications = PendingNotificationHelper.readAll()
            

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -167,7 +167,9 @@ open class Kumulos {
         instance!.initializeHelpers()
         
         if #available(iOS 10.0, *) {
-            instance!.maybeTrackPushDismissedEvents()
+            DispatchQueue.global().asyncAfter(deadline: .now() + 5.0) {
+                instance!.maybeTrackPushDismissedEvents()
+            }
         }
         
         DispatchQueue.global().async {

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -165,7 +165,11 @@ open class Kumulos {
         instance = Kumulos(config: config)
 
         instance!.initializeHelpers()
-
+        
+        if #available(iOS 10.0, *) {
+            instance!.maybeTrackPushDismissedEvents()
+        }
+        
         DispatchQueue.global().async {
             instance!.sendDeviceInformation()
         }

--- a/Sources/Kumulos.swift
+++ b/Sources/Kumulos.swift
@@ -58,7 +58,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "8.7.1"
+    internal let sdkVersion : String = "8.8.0"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/Shared/KumulosUserDefaultsKey.swift
+++ b/Sources/Shared/KumulosUserDefaultsKey.swift
@@ -15,6 +15,7 @@ internal enum KumulosUserDefaultsKey : String {
     case INSTALL_UUID = "KumulosUUID"
     case USER_ID = "KumulosCurrentUserID"
     case BADGE_COUNT = "KumulosBadgeCount"
+    case PENDING_NOTIFICATIONS = "KumulosPendingNotifications"
     
     //exist only in standard defaults for app
     case MIGRATED_TO_GROUPS = "KumulosDidMigrateToAppGroups"
@@ -29,6 +30,7 @@ internal enum KumulosUserDefaultsKey : String {
         SECRET_KEY,
         INSTALL_UUID,
         USER_ID,
-        BADGE_COUNT
+        BADGE_COUNT,
+        PENDING_NOTIFICATIONS
     ]
 }

--- a/Sources/Shared/PendingNotification.swift
+++ b/Sources/Shared/PendingNotification.swift
@@ -1,0 +1,23 @@
+//
+//  PendingNotification.swift
+//  KumulosSDK
+//
+//  Created by Vladislav Voicehovics on 09/03/2021.
+//  Copyright © 2021 Kumulos. All rights reserved.
+//
+
+import Foundation
+
+public struct PendingNotification: Codable, Equatable {
+    public var id: Int
+    public var deliveredAt: Date
+    
+    public init(id: Int, deliveredAt: Date) {
+        self.id = id
+        self.deliveredAt = deliveredAt
+    }
+    
+    public static func == (lhs: PendingNotification, rhs: PendingNotification) -> Bool {
+        return lhs.id == rhs.id
+    }
+}

--- a/Sources/Shared/PendingNotification.swift
+++ b/Sources/Shared/PendingNotification.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 internal struct PendingNotification: Codable {
-    var id: Int
-    var deliveredAt: Date
-    var identifier: String
+    let id: Int
+    let deliveredAt: Date
+    let identifier: String
     
     init(id: Int, deliveredAt: Date, identifier: String) {
         self.id = id

--- a/Sources/Shared/PendingNotification.swift
+++ b/Sources/Shared/PendingNotification.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal struct PendingNotification: Codable, Equatable {
+internal struct PendingNotification: Codable {
     var id: Int
     var deliveredAt: Date
     var identifier: String

--- a/Sources/Shared/PendingNotification.swift
+++ b/Sources/Shared/PendingNotification.swift
@@ -8,16 +8,14 @@
 
 import Foundation
 
-public struct PendingNotification: Codable, Equatable {
-    public var id: Int
-    public var deliveredAt: Date
+internal struct PendingNotification: Codable, Equatable {
+    var id: Int
+    var deliveredAt: Date
+    var identifier: String
     
-    public init(id: Int, deliveredAt: Date) {
+    init(id: Int, deliveredAt: Date, identifier: String) {
         self.id = id
         self.deliveredAt = deliveredAt
-    }
-    
-    public static func == (lhs: PendingNotification, rhs: PendingNotification) -> Bool {
-        return lhs.id == rhs.id
+        self.identifier = identifier
     }
 }

--- a/Sources/Shared/PendingNotificationHelper.swift
+++ b/Sources/Shared/PendingNotificationHelper.swift
@@ -1,0 +1,53 @@
+//
+//  PendingNotificationHelper.swift
+//  KumulosSDK
+//
+//  Created by Vladislav Voicehovics on 09/03/2021.
+//  Copyright © 2021 Kumulos. All rights reserved.
+//
+
+import Foundation
+
+internal class PendingNotificationHelper {
+    static func remove(id: Int)
+    {
+        var pendingNotifications = readAll()
+       
+        if let i = pendingNotifications.firstIndex(where: { $0.id == id }) {
+            pendingNotifications.remove(at: i)
+            
+            save(pendingNotifications: pendingNotifications)
+        }
+    }
+    
+    static func readAll() -> [PendingNotification]
+    {
+        var pendingNotifications = [PendingNotification]();
+        if let data = KeyValPersistenceHelper.object(forKey: KumulosUserDefaultsKey.PENDING_NOTIFICATIONS.rawValue),
+           let decoded = try? JSONDecoder().decode([PendingNotification].self, from: data as! Data){
+            pendingNotifications = decoded
+        }
+        
+        return pendingNotifications
+    }
+
+    static func add(notification: PendingNotification)
+    {
+        var pendingNotifications = readAll()
+       
+        if let _ = pendingNotifications.firstIndex(where: { $0.id == notification.id }) {
+            return
+        }
+        
+        pendingNotifications.append(notification)
+        
+        save(pendingNotifications: pendingNotifications)
+    }
+    
+    fileprivate static func save(pendingNotifications: [PendingNotification])
+    {
+        if let data = try? JSONEncoder().encode(pendingNotifications) {
+            KeyValPersistenceHelper.set(data, forKey: KumulosUserDefaultsKey.PENDING_NOTIFICATIONS.rawValue)
+        }
+    }
+}

--- a/Sources/Shared/PendingNotificationHelper.swift
+++ b/Sources/Shared/PendingNotificationHelper.swift
@@ -20,6 +20,17 @@ internal class PendingNotificationHelper {
         }
     }
     
+    static func remove(identifier: String)
+    {
+        var pendingNotifications = readAll()
+       
+        if let i = pendingNotifications.firstIndex(where: { $0.identifier == identifier }) {
+            pendingNotifications.remove(at: i)
+            
+            save(pendingNotifications: pendingNotifications)
+        }
+    }
+    
     static func readAll() -> [PendingNotification]
     {
         var pendingNotifications = [PendingNotification]();


### PR DESCRIPTION
### Description of Changes

Add push notification dismissed event tracking. 
1) For `UNNotificationDismissActionIdentifier` action to be sent to notification center category must be set up and assigned to a notification. Hence, add category not only when there are buttons, but always. Similarly to delivery tracking this is done in NotificationServiceExtension, so, dismissed tracking will not work when no extension added.
2) When app is closed and user dismisses a notification, NotificationCenter methods are not called. In order to track dismissed we record every delivered notification id, identifier (needed to clear tickles) and deliveredAt into shared storage. Opening/dismissing notification clears it from storage. When app is opened we check notifications still in tray, in storage and track implied dismissals.
3) Reading notifications in tray, receiving `UNNotificationDismissActionIdentifier` action, NotificationServiceExtension are only available in ios10+. Dismissed tracking only works on ios10+
4) In order to reliably track dismissal need  extension (records every received notification with title) and app groups (shared storage to read pending notifications in main target) to be set up.
5) Dont track dismissed event when in-app tickle cleared
6) If user sets category, we dont add our dynamic category. Hence, our action buttons are ignored, dismissed action does not trigger NotificationCenter (dismissed still is tracked through implicit tracking)


Also return usage of `pushHandleOpen(withUserInfo: [AnyHashable: Any]?)` lost in ios support swing (ios9 -> ios10 -> ios9)

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

