### PR TITLE
In-app: mark as read

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.9.0;
+				MARKETING_VERSION = 8.10.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -472,7 +472,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.9.0;
+				MARKETING_VERSION = 8.10.0;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -615,7 +615,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.9.0;
+				MARKETING_VERSION = 8.10.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -643,7 +643,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.9.0;
+				MARKETING_VERSION = 8.10.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.9.0"
+  s.version = "8.10.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.9.0"
+  s.version = "8.10.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Run `carthage update` to install your dependencies then follow the [Carthage int
 
 Also link your project against:
 
--   SystemConfiguration.framework
--   MessageUI.framework (for iOS projects)
--   libc++
--   libz
+- SystemConfiguration.framework
+- MessageUI.framework (for iOS projects)
+- libc++
+- libz
 
 And add the `-ObjC` linker flag to 'Other Linker Flags' under 'Build Settings'.
 
@@ -43,7 +43,7 @@ In Xcode add a package dependency by selecting:
 File > Swift Packages > Add Package Dependency
 ```
 
-Choose this repository URL for the package repository and `8.9.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
+Choose this repository URL for the package repository and `8.10.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
 
 ## Initializing and using the SDK
 
@@ -68,8 +68,8 @@ This project is licensed under the MIT license with portions licensed under the 
 
 ## Requirements
 
--   iOS9+
--   Swift5.0
+- iOS9+
+- Swift5.0
 
 ## Swift Version Support
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 8.9'
+pod 'KumulosSdkSwift', '~> 8.10'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 8.9
+github "Kumulos/KumulosSdkSwift" ~> 8.10
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.

--- a/Sources/SDK/InApp/InAppHelper.swift
+++ b/Sources/SDK/InApp/InAppHelper.swift
@@ -735,7 +735,7 @@ internal class InAppHelper {
                 result = false
                 return
             }
-                
+            
             if (messageEntities.count == 1){
                 messageEntities[0].readAt = NSDate()
             }

--- a/Sources/SDK/InApp/InAppHelper.swift
+++ b/Sources/SDK/InApp/InAppHelper.swift
@@ -714,7 +714,8 @@ internal class InAppHelper {
             let fetchRequest:NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: "Message")
             fetchRequest.entity = entity
             fetchRequest.includesPendingChanges = false
-            fetchRequest.predicate = NSPredicate(format: "id = %i", withId)
+            fetchRequest.includesPropertyValues = false
+            fetchRequest.predicate = NSPredicate(format: "id = %i AND readAt = nil", withId)
             
             var messageEntities: [InAppMessageEntity]
             do {
@@ -725,6 +726,11 @@ internal class InAppHelper {
                 return;
             }
             
+            if (messageEntities.count == 0){
+                result = false
+                return
+            }
+                
             if (messageEntities.count == 1){
                 messageEntities[0].readAt = NSDate()
             }

--- a/Sources/SDK/InApp/InAppHelper.swift
+++ b/Sources/SDK/InApp/InAppHelper.swift
@@ -526,7 +526,7 @@ internal class InAppHelper {
     }
     
     internal func handleMessageOpened(message: InAppMessage) -> Void {
-        _ = markInboxItemRead(withId: message.id);
+        _ = markInboxItemRead(withId: message.id, shouldWait: false);
         
         let props: [String:Any] = ["type" : MESSAGE_TYPE_IN_APP, "id":message.id]
         Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_OPENED, properties: props)
@@ -705,9 +705,9 @@ internal class InAppHelper {
         return result
     }
     
-    func markInboxItemRead(withId : Int64) -> Bool {
+    func markInboxItemRead(withId : Int64, shouldWait: Bool) -> Bool {
         var result = true;
-        messagesContext!.performAndWait({
+        let block = {
             let context = self.messagesContext!
             let entity: NSEntityDescription? = NSEntityDescription.entity(forEntityName: "Message", in: context)
             
@@ -743,7 +743,9 @@ internal class InAppHelper {
                 print("Failed to mark as read message with id: \(withId) \(err)")
                 return
             }
-        });
+        }
+        shouldWait ? messagesContext!.performAndWait(block) : messagesContext!.perform(block);
+        
         
         if (!result){
             return result
@@ -765,7 +767,7 @@ internal class InAppHelper {
                 continue
             }
             
-            if (!markInboxItemRead(withId: item.id)){
+            if (!markInboxItemRead(withId: item.id, shouldWait: true)){
                 result = false
             }
         }

--- a/Sources/SDK/InApp/InAppHelper.swift
+++ b/Sources/SDK/InApp/InAppHelper.swift
@@ -397,7 +397,8 @@ internal class InAppHelper {
                 return
             }
             
-            //exceeders evicted after saving as fetchLimit is ignored when have unsaved changes
+            //exceeders evicted after saving because fetchOffset is ignored when have unsaved changes
+            //https://stackoverflow.com/questions/10725252/possible-issue-with-fetchlimit-and-fetchoffset-in-a-core-data-query
             let exceedersEvicted = evictMessagesExceedingLimit(context: context)
             if (exceedersEvicted.count > 0){
                 evicted += exceedersEvicted

--- a/Sources/SDK/InApp/InAppModels.swift
+++ b/Sources/SDK/InApp/InAppModels.swift
@@ -20,6 +20,8 @@ class InAppMessageEntity : NSManagedObject {
     @NSManaged var inboxFrom : NSDate?
     @NSManaged var inboxTo : NSDate?
     @NSManaged var expiresAt : NSDate?
+    @NSManaged var readAt : NSDate?
+    @NSManaged var sentAt : NSDate?
 }
 
 public class InAppMessage: NSObject {
@@ -30,6 +32,8 @@ public class InAppMessage: NSObject {
     internal(set) open var badgeConfig : NSDictionary?
     internal(set) open var inboxConfig : NSDictionary?
     internal(set) open var dismissedAt : NSDate?
+    internal(set) open var readAt : NSDate?
+    internal(set) open var sentAt : NSDate?
     
     init(entity: InAppMessageEntity) {
         id = Int64(entity.id)
@@ -39,6 +43,8 @@ public class InAppMessage: NSObject {
         badgeConfig = entity.badgeConfig?.copy() as? NSDictionary
         inboxConfig = entity.inboxConfig?.copy() as? NSDictionary
         dismissedAt = entity.dismissedAt?.copy() as? NSDate
+        readAt = entity.readAt?.copy() as? NSDate
+        sentAt = entity.sentAt?.copy() as? NSDate
     }
 
     public override func isEqual(_ object: Any?) -> Bool {

--- a/Sources/SDK/InApp/InAppPresenter.swift
+++ b/Sources/SDK/InApp/InAppPresenter.swift
@@ -326,7 +326,7 @@ class InAppPresenter : NSObject, WKScriptMessageHandler, WKNavigationDelegate{
         }
        else if (type == "MESSAGE_OPENED") {
             loadingSpinner?.stopAnimating()
-            Kumulos.sharedInstance.inAppHelper.trackMessageOpened(message: self.currentMessage!)
+            Kumulos.sharedInstance.inAppHelper.handleMessageOpened(message: self.currentMessage!)
        } else if (type  == "MESSAGE_CLOSED") {
             self.handleMessageClosed()
        } else if (type == "EXECUTE_ACTIONS") {

--- a/Sources/SDK/Kumulos.swift
+++ b/Sources/SDK/Kumulos.swift
@@ -58,7 +58,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "8.9.0"
+    internal let sdkVersion : String = "8.10.0"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/SDK/Kumulos.swift
+++ b/Sources/SDK/Kumulos.swift
@@ -30,6 +30,7 @@ internal enum KumulosEvent : String {
     case MESSAGE_DISMISSED = "k.message.dismissed"
     case MESSAGE_DELETED_FROM_INBOX = "k.message.inbox.deleted"
     case DEEP_LINK_MATCHED = "k.deepLink.matched"
+    case MESSAGE_READ = "k.message.read"
 }
 
 public typealias InAppDeepLinkHandlerBlock = ([AnyHashable:Any]) -> Void

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -15,7 +15,7 @@ public class InAppInboxItem {
     internal(set) open var availableFrom: Date?
     internal(set) open var availableTo: Date?
     internal(set) open var dismissedAt : Date?
-    internal var readAt : Date?
+    private var readAt : Date?
     
     init(entity: InAppMessageEntity) {
         id = Int64(entity.id)

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -15,6 +15,7 @@ public class InAppInboxItem {
     internal(set) open var availableFrom: Date?
     internal(set) open var availableTo: Date?
     internal(set) open var dismissedAt : Date?
+    internal var readAt : Date?
     
     init(entity: InAppMessageEntity) {
         id = Int64(entity.id)
@@ -27,6 +28,7 @@ public class InAppInboxItem {
         availableFrom = entity.inboxFrom?.copy() as? Date
         availableTo = entity.inboxTo?.copy() as? Date
         dismissedAt = entity.dismissedAt?.copy() as? Date
+        readAt = entity.readAt?.copy() as? Date
     }
 
     public func isAvailable() -> Bool {
@@ -37,6 +39,10 @@ public class InAppInboxItem {
         }
 
         return true;
+    }
+    
+    public func isRead() -> Bool {
+        return readAt != nil;
     }
 }
 
@@ -69,7 +75,7 @@ public class KumulosInApp {
             request.includesPendingChanges = false
             request.sortDescriptors = [ NSSortDescriptor(key: "updatedAt", ascending: false) ]
             request.predicate = NSPredicate(format: "(inboxConfig != nil)")
-            request.propertiesToFetch = ["id", "inboxConfig", "inboxFrom", "inboxTo", "dismissedAt"]
+            request.propertiesToFetch = ["id", "inboxConfig", "inboxFrom", "inboxTo", "dismissedAt", "readAt"]
             
             
             var items: [InAppMessageEntity] = []
@@ -107,5 +113,13 @@ public class KumulosInApp {
     
     public static func deleteMessageFromInbox(item: InAppInboxItem) -> Bool {
         return Kumulos.sharedInstance.inAppHelper.deleteMessageFromInbox(withId: item.id)
+    }
+    
+    public static func markAsRead(item: InAppInboxItem) -> Bool {
+        return Kumulos.sharedInstance.inAppHelper.markInboxItemRead(withId: item.id)
+    }
+    
+    public static func markAllInboxItemsAsRead() -> Bool {
+        return Kumulos.sharedInstance.inAppHelper.markAllInboxItemsAsRead()
     }
 }

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -120,6 +120,9 @@ public class KumulosInApp {
     }
     
     public static func markAsRead(item: InAppInboxItem) -> Bool {
+        if (item.isRead()){
+            return false
+        }
         return Kumulos.sharedInstance.inAppHelper.markInboxItemRead(withId: item.id)
     }
     

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -73,7 +73,11 @@ public class KumulosInApp {
             let request = NSFetchRequest<InAppMessageEntity>(entityName: "Message")
             request.returnsObjectsAsFaults = false
             request.includesPendingChanges = false
-            request.sortDescriptors = [ NSSortDescriptor(key: "updatedAt", ascending: false) ]
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "sentAt", ascending: false),
+                NSSortDescriptor(key: "updatedAt", ascending: false),
+                NSSortDescriptor(key: "id", ascending: false)
+            ]
             request.predicate = NSPredicate(format: "(inboxConfig != nil)")
             request.propertiesToFetch = ["id", "inboxConfig", "inboxFrom", "inboxTo", "dismissedAt", "readAt"]
             

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -123,7 +123,7 @@ public class KumulosInApp {
         if (item.isRead()){
             return false
         }
-        return Kumulos.sharedInstance.inAppHelper.markInboxItemRead(withId: item.id)
+        return Kumulos.sharedInstance.inAppHelper.markInboxItemRead(withId: item.id, shouldWait: true)
     }
     
     public static func markAllInboxItemsAsRead() -> Bool {


### PR DESCRIPTION
### Description of Changes

New message property 'read'. The meaning of ‘message read’ is “User has seen the message, but not necessarily opened it”. Mark message as read when
1) message opened
2) inbox item deleted
3) Inbox item explicitly marked by user as read. For this expose 2 new public methods: `markAsRead(item: InAppInboxItem) -> Bool` and `markAllInboxItemsAsRead() -> Bool`. Methods return true if all updates succeeded.

Additionally,
1) Consistent sort order of inbox items. `sentAt DESC, updatedAt DESC, inAppId DESC`. When presenting sorting fields same, but ASC
2) limit maximal amount of stored inApps to 50. Even if inbox is set to always, 51st message is going to be deleted (51st is the oldest).
3) Clear push tickle whenever inApp is deleted. We used to do this when message is dismissed, inbox item deleted or message is marked read (and other). Now also when message expires or when delete message exceeding limit

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

