### PR TITLE
In-app inbox extensions (updated hook, new fields, summary method)

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.10.0;
+				MARKETING_VERSION = 8.11.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -472,7 +472,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.10.0;
+				MARKETING_VERSION = 8.11.0;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -615,7 +615,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.10.0;
+				MARKETING_VERSION = 8.11.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -643,7 +643,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.10.0;
+				MARKETING_VERSION = 8.11.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.10.0"
+  s.version = "8.11.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.10.0"
+  s.version = "8.11.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 8.10'
+pod 'KumulosSdkSwift', '~> 8.11'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 8.10
+github "Kumulos/KumulosSdkSwift" ~> 8.11
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.
@@ -43,7 +43,7 @@ In Xcode add a package dependency by selecting:
 File > Swift Packages > Add Package Dependency
 ```
 
-Choose this repository URL for the package repository and `8.10.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
+Choose this repository URL for the package repository and `8.11.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
 
 ## Initializing and using the SDK
 

--- a/Sources/SDK/InApp/InAppHelper.swift
+++ b/Sources/SDK/InApp/InAppHelper.swift
@@ -814,17 +814,12 @@ internal class InAppHelper {
     }
     
     func readInboxSummary(inboxSummaryBlock: @escaping InboxSummaryBlock) -> Void {
-        if Kumulos.sharedInstance.inAppHelper.messagesContext == nil {
+        guard let context = Kumulos.sharedInstance.inAppHelper.messagesContext else {
             self.fireInboxSummaryCallback(callback: inboxSummaryBlock, summary: nil)
             return
         }
-
-        Kumulos.sharedInstance.inAppHelper.messagesContext!.perform({
-            guard let context = Kumulos.sharedInstance.inAppHelper.messagesContext else {
-                self.fireInboxSummaryCallback(callback: inboxSummaryBlock, summary: nil)
-                return
-            }
-            
+        
+        context.perform({
             let request = NSFetchRequest<InAppMessageEntity>(entityName: "Message")
             request.includesPendingChanges = false
             request.predicate = NSPredicate(format: "(inboxConfig != nil)")

--- a/Sources/SDK/InApp/InAppHelper.swift
+++ b/Sources/SDK/InApp/InAppHelper.swift
@@ -826,10 +826,9 @@ internal class InAppHelper {
             }
             
             let request = NSFetchRequest<InAppMessageEntity>(entityName: "Message")
-            request.returnsObjectsAsFaults = false
             request.includesPendingChanges = false
             request.predicate = NSPredicate(format: "(inboxConfig != nil)")
-            request.propertiesToFetch = ["id", "inboxFrom", "inboxTo", "readAt"]
+            request.propertiesToFetch = ["inboxFrom", "inboxTo", "readAt"]
             
             var items: [InAppMessageEntity] = []
             do {
@@ -844,9 +843,7 @@ internal class InAppHelper {
             var totalCount: Int64 = 0
             var unreadCount: Int64 = 0
             for item in items {
-                let inboxItem = InAppInboxItem(entity: item)
-
-                if inboxItem.isAvailable() == false {
+                if (!item.isAvailable()){
                     continue
                 }
                 

--- a/Sources/SDK/InApp/InAppHelper.swift
+++ b/Sources/SDK/InApp/InAppHelper.swift
@@ -324,6 +324,7 @@ internal class InAppHelper {
             dateParser.locale = Locale(identifier: "en_US_POSIX")
             dateParser.timeZone = TimeZone(secondsFromGMT: 0)
             
+            var fetchedWithInbox = false
             for message in messages {
                 let partId = message["id"] as! Int64
                 
@@ -363,6 +364,10 @@ internal class InAppHelper {
                 model.inboxConfig = message["inbox"] as? NSDictionary
                 
                 if (model.inboxConfig != nil){
+                    //crude way to refresh when new inbox, updated readAt, updated inbox title/subtite
+                    //may cause redundant refreshes (if message with inbox updated, but not inbox itself).
+                    fetchedWithInbox = true
+                    
                     let inbox = model.inboxConfig!
                     
                     model.inboxFrom = dateParser.date(from: inbox["from"] as? String ?? "") as NSDate?
@@ -387,7 +392,7 @@ internal class InAppHelper {
             }
             
             // Evict
-            var idsEvicted = evictMessages(context: context)
+            var (idsEvicted, evictedWithInbox) = evictMessages(context: context)
             
             do{
                 try context.save()
@@ -399,7 +404,7 @@ internal class InAppHelper {
             
             //exceeders evicted after saving because fetchOffset is ignored when have unsaved changes
             //https://stackoverflow.com/questions/10725252/possible-issue-with-fetchlimit-and-fetchoffset-in-a-core-data-query
-            let exceederIdsEvicted = evictMessagesExceedingLimit(context: context)
+            let (exceederIdsEvicted, evictedExceedersWithInbox) = evictMessagesExceedingLimit(context: context)
             if (exceederIdsEvicted.count > 0){
                 idsEvicted += exceederIdsEvicted
                 
@@ -419,6 +424,9 @@ internal class InAppHelper {
             UserDefaults.standard.set(lastSyncTime, forKey: KumulosUserDefaultsKey.MESSAGES_LAST_SYNC_TIME.rawValue)
             
             trackMessageDelivery(messages: messages)
+            
+            let inboxUpdated = fetchedWithInbox || evictedWithInbox || evictedExceedersWithInbox
+            KumulosInApp.maybeRunInboxUpdatedHandler(inboxNeedsUpdate: inboxUpdated)
         })
     }
     
@@ -434,7 +442,7 @@ internal class InAppHelper {
         }
     }
     
-    private func evictMessages(context: NSManagedObjectContext) -> [Int64] {
+    private func evictMessages(context: NSManagedObjectContext) -> ([Int64], Bool) {
         let fetchRequest:NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: "Message")
         fetchRequest.includesPendingChanges = true
         
@@ -453,19 +461,23 @@ internal class InAppHelper {
             toEvict = try context.fetch(fetchRequest) as! [InAppMessageEntity]
         } catch let err {
             print("Failed to evict messages: \(err)")
-            return [];
+            return ([], false);
         }
         
         var idsEvicted: [Int64] = []
+        var evictedInbox = false
         for messageToEvict in toEvict {
             idsEvicted.append(messageToEvict.id)
+            if (messageToEvict.inboxConfig != nil){
+                evictedInbox = true
+            }
             context.delete(messageToEvict)
         }
         
-        return idsEvicted
+        return (idsEvicted, evictedInbox)
     }
     
-    private func evictMessagesExceedingLimit(context: NSManagedObjectContext) -> [Int64] {
+    private func evictMessagesExceedingLimit(context: NSManagedObjectContext) -> ([Int64], Bool) {
         let fetchRequest:NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: "Message")
         fetchRequest.sortDescriptors = [
             NSSortDescriptor(key: "sentAt", ascending: false),
@@ -479,16 +491,20 @@ internal class InAppHelper {
             toEvict = try context.fetch(fetchRequest) as! [InAppMessageEntity]
         } catch let err {
             print("Failed to evict exceeding messages: \(err)")
-            return [];
+            return ([], false);
         }
         
         var idsEvicted: [Int64] = []
+        var evictedInbox = false
         for messageToEvict in toEvict {
             idsEvicted.append(messageToEvict.id)
+            if (messageToEvict.inboxConfig != nil){
+                evictedInbox = true
+            }
             context.delete(messageToEvict)
         }
         
-        return idsEvicted
+        return (idsEvicted, evictedInbox)
     }
     
     private func getMessagesToPresent(_ presentedWhenOptions: [String]) -> [InAppMessage] {
@@ -531,7 +547,14 @@ internal class InAppHelper {
     }
     
     internal func handleMessageOpened(message: InAppMessage) -> Void {
-        _ = markInboxItemRead(withId: message.id, shouldWait: false);
+        var markedRead = false
+        if (message.readAt == nil){
+            markedRead = markInboxItemRead(withId: message.id, shouldWait: false);
+        }
+       
+        if (message.inboxConfig != nil){
+            KumulosInApp.maybeRunInboxUpdatedHandler(inboxNeedsUpdate: markedRead);
+        }
         
         let props: [String:Any] = ["type" : MESSAGE_TYPE_IN_APP, "id":message.id]
         Kumulos.trackEvent(eventType: KumulosEvent.MESSAGE_OPENED, properties: props)
@@ -707,6 +730,8 @@ internal class InAppHelper {
             }
         });
         
+        KumulosInApp.maybeRunInboxUpdatedHandler(inboxNeedsUpdate: result);
+        
         return result
     }
     
@@ -767,15 +792,23 @@ internal class InAppHelper {
     func markAllInboxItemsAsRead() -> Bool {
         var result = true;
         let inboxItems = KumulosInApp.getInboxItems()
+        var inboxNeedsUpdate = false
         for item in inboxItems {
             if (item.isRead()){
                 continue
             }
             
-            if (!markInboxItemRead(withId: item.id, shouldWait: true)){
+            let success = markInboxItemRead(withId: item.id, shouldWait: true)
+            if (success && !inboxNeedsUpdate) {
+                inboxNeedsUpdate = true;
+            }
+            
+            if (!success){
                 result = false
             }
         }
+        
+        KumulosInApp.maybeRunInboxUpdatedHandler(inboxNeedsUpdate: inboxNeedsUpdate);
         
         return result
     }

--- a/Sources/SDK/InApp/InAppModels.swift
+++ b/Sources/SDK/InApp/InAppModels.swift
@@ -22,6 +22,19 @@ class InAppMessageEntity : NSManagedObject {
     @NSManaged var expiresAt : NSDate?
     @NSManaged var readAt : NSDate?
     @NSManaged var sentAt : NSDate?
+    
+    internal func isAvailable() -> Bool {
+        let availableFrom = inboxFrom as Date?
+        let availableTo = inboxTo as Date?
+        
+        if (availableFrom != nil && availableFrom!.timeIntervalSinceNow > 0) {
+            return false;
+        } else if (availableTo != nil && availableTo!.timeIntervalSinceNow < 0) {
+            return false;
+        }
+
+        return true;
+    }
 }
 
 public class InAppMessage: NSObject {

--- a/Sources/SDK/Kumulos.swift
+++ b/Sources/SDK/Kumulos.swift
@@ -59,7 +59,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "8.10.0"
+    internal let sdkVersion : String = "8.11.0"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -59,11 +59,6 @@ public class InAppInboxItem {
 public struct InAppInboxSummary {
     public let totalCount: Int64
     public let unreadCount: Int64
-    
-    init(totalCount: Int64, unreadCount: Int64) {
-        self.totalCount = totalCount
-        self.unreadCount = unreadCount
-    }
 }
 
 public typealias InboxUpdatedHandlerBlock = () -> Void

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -90,7 +90,6 @@ public class KumulosInApp {
             }
             
             let request = NSFetchRequest<InAppMessageEntity>(entityName: "Message")
-            request.returnsObjectsAsFaults = false
             request.includesPendingChanges = false
             request.sortDescriptors = [
                 NSSortDescriptor(key: "sentAt", ascending: false),
@@ -98,8 +97,7 @@ public class KumulosInApp {
                 NSSortDescriptor(key: "id", ascending: false)
             ]
             request.predicate = NSPredicate(format: "(inboxConfig != nil)")
-            request.propertiesToFetch = ["id", "inboxConfig", "inboxFrom", "inboxTo", "dismissedAt", "readAt"]
-            
+            request.propertiesToFetch = ["id", "inboxConfig", "inboxFrom", "inboxTo", "dismissedAt", "readAt", "sentAt", "data"]
             
             var items: [InAppMessageEntity] = []
             do {
@@ -152,7 +150,7 @@ public class KumulosInApp {
         return Kumulos.sharedInstance.inAppHelper.markAllInboxItemsAsRead()
     }
     
-    public static func setOnInboxUpdatedHandler(inboxUpdatedHandlerBlock: InboxUpdatedHandlerBlock?) -> Void {
+    public static func setOnInboxUpdated(inboxUpdatedHandlerBlock: InboxUpdatedHandlerBlock?) -> Void {
         _inboxUpdatedHandlerBlock = inboxUpdatedHandlerBlock
     }
     

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -56,9 +56,9 @@ public class InAppInboxItem {
     }
 }
 
-public class InAppInboxSummary: NSObject {
-    private(set) open var totalCount: Int64
-    private(set) open var unreadCount: Int64
+public struct InAppInboxSummary {
+    public let totalCount: Int64
+    public let unreadCount: Int64
     
     init(totalCount: Int64, unreadCount: Int64) {
         self.totalCount = totalCount

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -82,19 +82,13 @@ public class KumulosInApp {
         Kumulos.sharedInstance.inAppHelper.updateUserConsent(consentGiven: consentGiven)
     }
     
-    public static func getInboxItems() -> [InAppInboxItem]
-     {
-        if Kumulos.sharedInstance.inAppHelper.messagesContext == nil {
+    public static func getInboxItems() -> [InAppInboxItem] {
+        guard let context = Kumulos.sharedInstance.inAppHelper.messagesContext else {
             return []
         }
-
+    
         var results: [InAppInboxItem] = []
-        
-        Kumulos.sharedInstance.inAppHelper.messagesContext!.performAndWait({
-            guard let context = Kumulos.sharedInstance.inAppHelper.messagesContext else {
-                return
-            }
-            
+        context.performAndWait({
             let request = NSFetchRequest<InAppMessageEntity>(entityName: "Message")
             request.includesPendingChanges = false
             request.sortDescriptors = [

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -15,7 +15,7 @@ public class InAppInboxItem {
     internal(set) open var availableFrom: Date?
     internal(set) open var availableTo: Date?
     internal(set) open var dismissedAt : Date?
-    internal(set) open var sentAt: Date?//TODO: backfill?
+    internal(set) open var sentAt: Date
     internal(set) open var data: NSDictionary?
     private var readAt : Date?
     
@@ -31,8 +31,14 @@ public class InAppInboxItem {
         availableTo = entity.inboxTo?.copy() as? Date
         dismissedAt = entity.dismissedAt?.copy() as? Date
         readAt = entity.readAt?.copy() as? Date
-        sentAt = entity.sentAt?.copy() as? Date
         data = entity.data?.copy() as? NSDictionary
+        
+        if let sentAtNonNil = entity.sentAt?.copy() as? Date {
+            sentAt = sentAtNonNil
+        }
+        else{
+            sentAt = entity.updatedAt.copy() as! Date
+        }
     }
 
     public func isAvailable() -> Bool {
@@ -97,7 +103,7 @@ public class KumulosInApp {
                 NSSortDescriptor(key: "id", ascending: false)
             ]
             request.predicate = NSPredicate(format: "(inboxConfig != nil)")
-            request.propertiesToFetch = ["id", "inboxConfig", "inboxFrom", "inboxTo", "dismissedAt", "readAt", "sentAt", "data"]
+            request.propertiesToFetch = ["id", "inboxConfig", "inboxFrom", "inboxTo", "dismissedAt", "readAt", "sentAt", "data", "updatedAt"]
             
             var items: [InAppMessageEntity] = []
             do {

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -15,6 +15,8 @@ public class InAppInboxItem {
     internal(set) open var availableFrom: Date?
     internal(set) open var availableTo: Date?
     internal(set) open var dismissedAt : Date?
+    internal(set) open var sentAt: Date?//TODO: backfill?
+    internal(set) open var data: NSDictionary?
     private var readAt : Date?
     
     init(entity: InAppMessageEntity) {
@@ -29,6 +31,8 @@ public class InAppInboxItem {
         availableTo = entity.inboxTo?.copy() as? Date
         dismissedAt = entity.dismissedAt?.copy() as? Date
         readAt = entity.readAt?.copy() as? Date
+        sentAt = entity.sentAt?.copy() as? Date
+        data = entity.data?.copy() as? NSDictionary
     }
 
     public func isAvailable() -> Bool {

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -50,7 +50,18 @@ public class InAppInboxItem {
     }
 }
 
+public class InAppInboxSummary: NSObject {
+    private(set) open var totalCount: Int64
+    private(set) open var unreadCount: Int64
+    
+    init(totalCount: Int64, unreadCount: Int64) {
+        self.totalCount = totalCount
+        self.unreadCount = unreadCount
+    }
+}
+
 public typealias InboxUpdatedHandlerBlock = () -> Void
+public typealias InboxSummaryBlock = (InAppInboxSummary?) -> Void
 
 public class KumulosInApp {
     private static var _inboxUpdatedHandlerBlock: InboxUpdatedHandlerBlock?
@@ -145,6 +156,12 @@ public class KumulosInApp {
         _inboxUpdatedHandlerBlock = inboxUpdatedHandlerBlock
     }
     
+    public static func getInboxSummaryAsync(inboxSummaryBlock: @escaping InboxSummaryBlock){
+        Kumulos.sharedInstance.inAppHelper.readInboxSummary(inboxSummaryBlock: inboxSummaryBlock)
+    }
+    
+
+    // Internal helpers
     static func maybeRunInboxUpdatedHandler(inboxNeedsUpdate: Bool) -> Void {
         if (!inboxNeedsUpdate){
             return;


### PR DESCRIPTION
### Description of Changes

Port of android [56](https://github.com/Kumulos/KumulosSdkAndroid/pull/56)

1) Inbox updated handler:

```
KumulosInApp.setOnInboxUpdated(inboxUpdatedHandlerBlock: {() -> Void in
     print("win")
});

```
Callback runs every time there are changes relevant for inbox presentation. These are: 
- markRead
- markAllRead
- messageOpened (for this to work properly need to add `readAt` and `inbox` to every message in presentation queue)
- deleteInboxMessage
- sync
- eviction

The callback is run on main thread. It is a responsibility of users to make sure `getInboxItems` (which is sync) they might wish to run afterwards is not blocking UI. 

Edge cases:
- inbox message drops out of availability window. It stays in inbox until evicted with next sync. This is very unlikely and badge and inbox both lag and then both get updated. If try to open such message get result EXPIRED as before
-  If we manually set inbox to null in db (e.g. customer request), inbox will not refresh. To make it refresh would need to set inbox expiry and message expiry.

2) `getInboxSummary` with async callback, e.g.
```
KumulosInApp.getInboxSummaryAsync(inboxSummaryBlock: {(summary:InAppInboxSummary?) -> Void in
     if let inboxSummary = summary {
        print("total: \(inboxSummary.totalCount) unread: \(inboxSummary.unreadCount)")
     }
});
```
3) expose `sentAt` and `data` on inbox items


### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

