### PR TITLE
Decrease session idle timeout

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.0;
+				MARKETING_VERSION = 8.11.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -472,7 +472,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.0;
+				MARKETING_VERSION = 8.11.1;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -615,7 +615,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.0;
+				MARKETING_VERSION = 8.11.1;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -643,7 +643,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.0;
+				MARKETING_VERSION = 8.11.1;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.11.0"
+  s.version = "8.11.1"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.11.0"
+  s.version = "8.11.1"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 8.11'
+pod 'KumulosSdkSwift', '~> 8.11.1'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 8.11
+github "Kumulos/KumulosSdkSwift" ~> 8.11.1
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.
@@ -43,7 +43,7 @@ In Xcode add a package dependency by selecting:
 File > Swift Packages > Add Package Dependency
 ```
 
-Choose this repository URL for the package repository and `8.11.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
+Choose this repository URL for the package repository and `8.11.1` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
 
 ## Initializing and using the SDK
 

--- a/Sources/SDK/KSConfig.swift
+++ b/Sources/SDK/KSConfig.swift
@@ -48,7 +48,7 @@ open class KSConfigBuilder: NSObject {
         _apiKey = apiKey
         _secretKey = secretKey
         _enableCrash = false
-        _sessionIdleTimeout = 25
+        _sessionIdleTimeout = 23
     }
     
     public func enableCrash() -> KSConfigBuilder {

--- a/Sources/SDK/KSConfig.swift
+++ b/Sources/SDK/KSConfig.swift
@@ -48,7 +48,7 @@ open class KSConfigBuilder: NSObject {
         _apiKey = apiKey
         _secretKey = secretKey
         _enableCrash = false
-        _sessionIdleTimeout = 40
+        _sessionIdleTimeout = 25
     }
     
     public func enableCrash() -> KSConfigBuilder {

--- a/Sources/SDK/Kumulos.swift
+++ b/Sources/SDK/Kumulos.swift
@@ -59,7 +59,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "8.11.0"
+    internal let sdkVersion : String = "8.11.1"
 
     var networkRequestsInProgress = 0
 


### PR DESCRIPTION
### Description of Changes

iOS 13+ gives background task ~30s before it runs `expirationHandler`. Previously this was minutes.

Hence, we dont manage to do event sync when app goes bg. Drop the value to 23 sec

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

