### PR TITLE
Pass webInstallId query parameter when reading a deep link

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.1;
+				MARKETING_VERSION = 8.11.2;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -472,7 +472,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.1;
+				MARKETING_VERSION = 8.11.2;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -615,7 +615,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.1;
+				MARKETING_VERSION = 8.11.2;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -643,7 +643,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.1;
+				MARKETING_VERSION = 8.11.2;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.11.1"
+  s.version = "8.11.2"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.11.1"
+  s.version = "8.11.2"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 8.11.1'
+pod 'KumulosSdkSwift', '~> 8.11.2'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 8.11.1
+github "Kumulos/KumulosSdkSwift" ~> 8.11.2
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.
@@ -43,7 +43,7 @@ In Xcode add a package dependency by selecting:
 File > Swift Packages > Add Package Dependency
 ```
 
-Choose this repository URL for the package repository and `8.11.1` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
+Choose this repository URL for the package repository and `8.11.2` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
 
 ## Initializing and using the SDK
 

--- a/Sources/SDK/Kumulos+DeepLinking.swift
+++ b/Sources/SDK/Kumulos+DeepLinking.swift
@@ -91,10 +91,9 @@ class DeepLinkHelper {
     fileprivate func handleDeepLinkUrl(_ url: URL, wasDeferred: Bool = false) {
         let slug = KSHttpUtil.urlEncode(url.path.trimmingCharacters(in: ["/"]))
 
-        let path = "/v1/deeplinks/\(slug ?? "")?wasDeferred=\(wasDeferred ? 1 : 0)"
-        let webInstallId = KSHttpUtil.getQueryStringParameter(url.absoluteString, "webInstallId");
-        if (webInstallId != nil){
-            path = path + "&webInstallId=" + webInstallId;
+        var path = "/v1/deeplinks/\(slug ?? "")?wasDeferred=\(wasDeferred ? 1 : 0)"
+        if let webInstallId = KSHttpUtil.getQueryStringParameter(url.absoluteString, "webInstallId") {
+            path = path + "&webInstallId=" + webInstallId
         }
         
         httpClient.sendRequest(.GET, toPath: path, data: nil, onSuccess:  { (res, data) in

--- a/Sources/SDK/Kumulos+DeepLinking.swift
+++ b/Sources/SDK/Kumulos+DeepLinking.swift
@@ -92,8 +92,8 @@ class DeepLinkHelper {
         let slug = KSHttpUtil.urlEncode(url.path.trimmingCharacters(in: ["/"]))
 
         var path = "/v1/deeplinks/\(slug ?? "")?wasDeferred=\(wasDeferred ? 1 : 0)"
-        if let webInstallId = KSHttpUtil.getQueryStringParameter(url.absoluteString, "webInstallId") {
-            path = path + "&webInstallId=" + webInstallId
+        if let query = url.query {
+            path = path + "&" + query
         }
         
         httpClient.sendRequest(.GET, toPath: path, data: nil, onSuccess:  { (res, data) in

--- a/Sources/SDK/Kumulos+DeepLinking.swift
+++ b/Sources/SDK/Kumulos+DeepLinking.swift
@@ -92,7 +92,11 @@ class DeepLinkHelper {
         let slug = KSHttpUtil.urlEncode(url.path.trimmingCharacters(in: ["/"]))
 
         let path = "/v1/deeplinks/\(slug ?? "")?wasDeferred=\(wasDeferred ? 1 : 0)"
-
+        let webInstallId = KSHttpUtil.getQueryStringParameter(url.absoluteString, "webInstallId");
+        if (webInstallId != nil){
+            path = path + "&webInstallId=" + webInstallId;
+        }
+        
         httpClient.sendRequest(.GET, toPath: path, data: nil, onSuccess:  { (res, data) in
             switch res?.statusCode {
             case 200:

--- a/Sources/SDK/Kumulos.swift
+++ b/Sources/SDK/Kumulos.swift
@@ -59,7 +59,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "8.11.1"
+    internal let sdkVersion : String = "8.11.2"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/Shared/KSHttp.swift
+++ b/Sources/Shared/KSHttp.swift
@@ -199,9 +199,4 @@ internal struct KSHttpUtil {
 
         return encoded
     }
-    
-    static func getQueryStringParameter(_ url: String, _ param: String) -> String? {
-      guard let url = URLComponents(string: url) else { return nil }
-      return url.queryItems?.first(where: { $0.name == param })?.value
-    }
 }

--- a/Sources/Shared/KSHttp.swift
+++ b/Sources/Shared/KSHttp.swift
@@ -200,7 +200,7 @@ internal struct KSHttpUtil {
         return encoded
     }
     
-    static func getQueryStringParameter(url: String, param: String) -> String? {
+    static func getQueryStringParameter(_ url: String, _ param: String) -> String? {
       guard let url = URLComponents(string: url) else { return nil }
       return url.queryItems?.first(where: { $0.name == param })?.value
     }

--- a/Sources/Shared/KSHttp.swift
+++ b/Sources/Shared/KSHttp.swift
@@ -199,4 +199,9 @@ internal struct KSHttpUtil {
 
         return encoded
     }
+    
+    static func getQueryStringParameter(url: String, param: String) -> String? {
+      guard let url = URLComponents(string: url) else { return nil }
+      return url.queryItems?.first(where: { $0.name == param })?.value
+    }
 }


### PR DESCRIPTION
### Description of Changes

If deep link is opened by clicking a banner (WebSDK) extra query parameter is present on the copied URL. Pass it to API when reading deep link in order to track conversion.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

