### PR TITLE
SDK parity with Objc

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		B625D075233A7A18003AA551 /* InAppPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B625D072233A7A17003AA551 /* InAppPresenter.swift */; };
 		B625D076233A7A18003AA551 /* InAppHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B625D073233A7A17003AA551 /* InAppHelper.swift */; };
 		B625D077233A7A18003AA551 /* InAppModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B625D074233A7A17003AA551 /* InAppModels.swift */; };
+		B62819402693563800D7B876 /* MediaHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B628193F2693563700D7B876 /* MediaHelper.swift */; };
+		B62819412693563800D7B876 /* MediaHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B628193F2693563700D7B876 /* MediaHelper.swift */; };
 		B62FB895242384020070A79D /* KumulosUserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62FB894242384020070A79D /* KumulosUserDefaultsKey.swift */; };
 		B62FB8982423997E0070A79D /* AppGroupsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62FB8972423997E0070A79D /* AppGroupsHelper.swift */; };
 		B62FB8A6242448520070A79D /* KumulosHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62FB8A5242448520070A79D /* KumulosHelper.swift */; };
@@ -100,6 +102,7 @@
 		B625D072233A7A17003AA551 /* InAppPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppPresenter.swift; sourceTree = "<group>"; };
 		B625D073233A7A17003AA551 /* InAppHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppHelper.swift; sourceTree = "<group>"; };
 		B625D074233A7A17003AA551 /* InAppModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppModels.swift; sourceTree = "<group>"; };
+		B628193F2693563700D7B876 /* MediaHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaHelper.swift; sourceTree = "<group>"; };
 		B62FB894242384020070A79D /* KumulosUserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KumulosUserDefaultsKey.swift; sourceTree = "<group>"; };
 		B62FB8972423997E0070A79D /* AppGroupsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupsHelper.swift; sourceTree = "<group>"; };
 		B62FB8A5242448520070A79D /* KumulosHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KumulosHelper.swift; path = Sources/Shared/KumulosHelper.swift; sourceTree = SOURCE_ROOT; };
@@ -219,6 +222,7 @@
 				B62FB8972423997E0070A79D /* AppGroupsHelper.swift */,
 				B659805525F7CE98008C074D /* PendingNotification.swift */,
 				B659805C25F81F5C008C074D /* PendingNotificationHelper.swift */,
+				B628193F2693563700D7B876 /* MediaHelper.swift */,
 			);
 			name = Shared;
 			path = Sources/Shared;
@@ -370,6 +374,7 @@
 				B62FB8B02424622F0070A79D /* KSHttp.swift in Sources */,
 				B62FB8AA24244EFC0070A79D /* KeyValPersistenceHelper.swift in Sources */,
 				B659805725F7CE98008C074D /* PendingNotification.swift in Sources */,
+				B62819412693563800D7B876 /* MediaHelper.swift in Sources */,
 				B62FB8AF242461C70070A79D /* AnalyticsHelper.swift in Sources */,
 				B62FB8AB24244EFE0070A79D /* AppGroupsHelper.swift in Sources */,
 				B659805E25F81F5C008C074D /* PendingNotificationHelper.swift in Sources */,
@@ -393,6 +398,7 @@
 				123D90A822A160D0004B8392 /* KSHttp.swift in Sources */,
 				127B22DB1D9BE59E00D9C94B /* KSAPIOperation.swift in Sources */,
 				127B22DE1D9BE59E00D9C94B /* Kumulos+API.swift in Sources */,
+				B62819402693563800D7B876 /* MediaHelper.swift in Sources */,
 				B62FB8982423997E0070A79D /* AppGroupsHelper.swift in Sources */,
 				127B22DD1D9BE59E00D9C94B /* Kumulos.swift in Sources */,
 				B625D076233A7A18003AA551 /* InAppHelper.swift in Sources */,

--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.2;
+				MARKETING_VERSION = 9.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -478,7 +478,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.2;
+				MARKETING_VERSION = 9.0.0;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -621,7 +621,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.2;
+				MARKETING_VERSION = 9.0.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -649,7 +649,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.11.2;
+				MARKETING_VERSION = 9.0.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 8.12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -478,7 +478,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 8.12.0;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -621,7 +621,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 8.12.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -649,7 +649,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 8.12.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "9.0.0"
+  s.version = "8.12.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.11.2"
+  s.version = "9.0.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "9.0.0"
+  s.version = "8.12.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.11.2"
+  s.version = "9.0.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 8.11.2'
+pod 'KumulosSdkSwift', '~> 9.0.0'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 8.11.2
+github "Kumulos/KumulosSdkSwift" ~> 9.0.0
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.
@@ -43,7 +43,7 @@ In Xcode add a package dependency by selecting:
 File > Swift Packages > Add Package Dependency
 ```
 
-Choose this repository URL for the package repository and `8.11.2` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
+Choose this repository URL for the package repository and `9.0.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
 
 ## Initializing and using the SDK
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 9.0.0'
+pod 'KumulosSdkSwift', '~> 8.12.0'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 9.0.0
+github "Kumulos/KumulosSdkSwift" ~> 8.12.0
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.
@@ -43,7 +43,7 @@ In Xcode add a package dependency by selecting:
 File > Swift Packages > Add Package Dependency
 ```
 
-Choose this repository URL for the package repository and `9.0.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
+Choose this repository URL for the package repository and `8.12.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
 
 ## Initializing and using the SDK
 

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -109,13 +109,11 @@ public class KumulosNotificationService {
         let attachments = userInfo["attachments"] as? [AnyHashable : Any]
         let pictureUrl = attachments?["pictureUrl"] as? String
 
-        if pictureUrl == nil {
-            return
-        }
+        guard let picUrlNonNull = pictureUrl else { return }
 
-        let picExtension = getPictureExtension(pictureUrl)
-        let url = getCompletePictureUrl(pictureUrl!)
-
+        let picExtension = getPictureExtension(picUrlNonNull)
+        let url = MediaHelper.getCompletePictureUrl(pictureUrl: picUrlNonNull as String, width: UInt(floor(UIScreen.main.bounds.size.width)))
+        
         dispatchGroup.enter()
 
         loadAttachment(url!, withExtension: picExtension, completionHandler: { attachment in
@@ -137,18 +135,6 @@ public class KumulosNotificationService {
         }
 
         return "." + (pictureExtension)
-    }
-
-    fileprivate class func getCompletePictureUrl(_ pictureUrl: String) -> URL? {
-        if (((pictureUrl as NSString).substring(with: NSRange(location: 0, length: 8))) == "https://") || (((pictureUrl as NSString).substring(with: NSRange(location: 0, length: 7))) == "http://") {
-            return URL(string: pictureUrl)
-        }
-
-        let width = UIScreen.main.bounds.size.width
-        let num = Int(floor(width))
-
-        let completeString = String(format: "%@%@%ld%@%@", KS_MEDIA_RESIZER_BASE_URL, "/", num, "x/", pictureUrl)
-        return URL(string: completeString)
     }
 
     fileprivate class func loadAttachment(_ url: URL, withExtension pictureExtension: String?, completionHandler: @escaping (UNNotificationAttachment?) -> Void) {

--- a/Sources/SDK/Kumulos.swift
+++ b/Sources/SDK/Kumulos.swift
@@ -59,7 +59,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "9.0.0"
+    internal let sdkVersion : String = "8.12.0"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/SDK/Kumulos.swift
+++ b/Sources/SDK/Kumulos.swift
@@ -59,7 +59,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "8.11.2"
+    internal let sdkVersion : String = "9.0.0"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/SDK/KumulosInApp.swift
+++ b/Sources/SDK/KumulosInApp.swift
@@ -18,6 +18,9 @@ public class InAppInboxItem {
     internal(set) open var sentAt: Date
     internal(set) open var data: NSDictionary?
     private var readAt : Date?
+    private var imagePath: String?
+    
+    private static let defaultImageWidth: UInt = 300
     
     init(entity: InAppMessageEntity) {
         id = Int64(entity.id)
@@ -39,6 +42,8 @@ public class InAppInboxItem {
         else{
             sentAt = entity.updatedAt.copy() as! Date
         }
+        
+        imagePath = inboxConfig["imagePath"] as? String
     }
 
     public func isAvailable() -> Bool {
@@ -53,6 +58,18 @@ public class InAppInboxItem {
     
     public func isRead() -> Bool {
         return readAt != nil;
+    }
+    
+    public func getImageUrl() -> URL? {
+        return self.getImageUrl(width: InAppInboxItem.defaultImageWidth)
+    }
+    
+    public func getImageUrl(width: UInt) -> URL? {
+        if let imagePathNotNil = imagePath {
+            return MediaHelper.getCompletePictureUrl(pictureUrl: imagePathNotNil, width: width)
+        }
+        
+        return nil
     }
 }
 
@@ -152,7 +169,6 @@ public class KumulosInApp {
     public static func getInboxSummaryAsync(inboxSummaryBlock: @escaping InboxSummaryBlock){
         Kumulos.sharedInstance.inAppHelper.readInboxSummary(inboxSummaryBlock: inboxSummaryBlock)
     }
-    
 
     // Internal helpers
     static func maybeRunInboxUpdatedHandler(inboxNeedsUpdate: Bool) -> Void {

--- a/Sources/Shared/MediaHelper.swift
+++ b/Sources/Shared/MediaHelper.swift
@@ -1,0 +1,23 @@
+//
+//  MediaHelper.swift
+//  KumulosSDK
+//
+//  Created by Vladislav Voicehovics on 05/07/2021.
+//  Copyright © 2021 Kumulos. All rights reserved.
+//
+
+import Foundation
+
+public class MediaHelper {
+    private static let mediaResizerBaseUrl: String = "https://i.app.delivery"
+    
+    internal static func getCompletePictureUrl(pictureUrl: String, width: UInt) -> URL? {
+        
+        if (((pictureUrl as NSString).substring(with: NSRange(location: 0, length: 8))) == "https://") || (((pictureUrl as NSString).substring(with: NSRange(location: 0, length: 7))) == "http://") {
+            return URL(string: pictureUrl)
+        }
+
+        let completeString = String(format: "%@%@%ld%@%@", MediaHelper.mediaResizerBaseUrl, "/", width, "x/", pictureUrl)
+        return URL(string: completeString)
+    }
+}


### PR DESCRIPTION
### Description of Changes

1) Inbox image url. Ported from Objc [60](https://github.com/Kumulos/KumulosSdkObjectiveC/pull/60)

### Breaking Changes

None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

