### PR TITLE
Implement heuristic link resolution for Web-to-App banners edge cases

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		12020A4326B30E78002B235B /* DeepLinkFingerprinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12020A4226B30E78002B235B /* DeepLinkFingerprinter.swift */; };
 		123D90A822A160D0004B8392 /* KSHttp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123D90A722A160CF004B8392 /* KSHttp.swift */; };
 		126F12632507EAB2007DBBE1 /* KumulosCheckins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 126F12622507EAB2007DBBE1 /* KumulosCheckins.swift */; };
 		127B22D91D9BE59E00D9C94B /* CwlSysctl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127B22CE1D9BE59E00D9C94B /* CwlSysctl.swift */; };
@@ -62,6 +63,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		12020A4226B30E78002B235B /* DeepLinkFingerprinter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DeepLinkFingerprinter.swift; path = Sources/SDK/DeepLinkFingerprinter.swift; sourceTree = "<group>"; };
 		123D90A722A160CF004B8392 /* KSHttp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KSHttp.swift; sourceTree = "<group>"; };
 		126F12622507EAB2007DBBE1 /* KumulosCheckins.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KumulosCheckins.swift; path = Sources/SDK/KumulosCheckins.swift; sourceTree = "<group>"; };
 		127B22CE1D9BE59E00D9C94B /* CwlSysctl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CwlSysctl.swift; path = Sources/SDK/CwlSysctl.swift; sourceTree = "<group>"; };
@@ -173,6 +175,7 @@
 				127B22D41D9BE59E00D9C94B /* Kumulos+Push.swift */,
 				127B22D51D9BE59E00D9C94B /* Kumulos+Stats.swift */,
 				12862D7F252F74FC00BD0E77 /* Kumulos+DeepLinking.swift */,
+				12020A4226B30E78002B235B /* DeepLinkFingerprinter.swift */,
 				A16790811E49D8BD00C276AF /* KumulosPushChannels.swift */,
 				126F12622507EAB2007DBBE1 /* KumulosCheckins.swift */,
 				127B22D61D9BE59E00D9C94B /* KumulosSDK.h */,
@@ -313,7 +316,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1110;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = Kumulos;
 				TargetAttributes = {
 					12985A59238D6F3100671FBF = {
@@ -401,6 +404,7 @@
 				B62819402693563800D7B876 /* MediaHelper.swift in Sources */,
 				B62FB8982423997E0070A79D /* AppGroupsHelper.swift in Sources */,
 				127B22DD1D9BE59E00D9C94B /* Kumulos.swift in Sources */,
+				12020A4326B30E78002B235B /* DeepLinkFingerprinter.swift in Sources */,
 				B625D076233A7A18003AA551 /* InAppHelper.swift in Sources */,
 				B625D075233A7A18003AA551 /* InAppPresenter.swift in Sources */,
 				127B22DC1D9BE59E00D9C94B /* KSResponse.swift in Sources */,
@@ -512,6 +516,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -573,6 +578,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;

--- a/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDK.xcscheme
+++ b/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDK.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKExtension.xcscheme
+++ b/KumulosSDK.xcodeproj/xcshareddata/xcschemes/KumulosSDKExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/Sources/SDK/DeepLinkFingerprinter.swift
+++ b/Sources/SDK/DeepLinkFingerprinter.swift
@@ -1,0 +1,141 @@
+//
+//  DeepLinkFingerprinter.swift
+//  KumulosSDK
+//
+//  Copyright © 2021 Kumulos. All rights reserved.
+//
+
+import Foundation
+import WebKit
+
+fileprivate enum PrintDustMessage : String {
+    case clientReady =  "READY"
+    case clientFingerprintGeneraged = "FINGERPRINT_GENERATED"
+    case requestFingerprint = "REQUEST_FINGERPRINT"
+}
+
+fileprivate enum DeferredState<R> {
+    case pending
+    case resolved(R)
+}
+
+// TODO: consider rejection / timeouts?
+fileprivate class Deferred<R> {
+    var state : DeferredState<R>
+    var pendingWatchers : [(R) -> Void]
+
+    init() {
+        state = .pending
+        pendingWatchers = []
+    }
+
+    func resolve(result: R) {
+        DispatchQueue.main.async {
+            switch (self.state) {
+            case .resolved(_): return
+            default: break
+            }
+
+            self.state = DeferredState.resolved(result)
+
+            self.pendingWatchers.forEach { cb in
+                cb(result)
+            }
+
+            self.pendingWatchers.removeAll()
+        }
+    }
+
+    func then(onResult: @escaping (R) -> Void) {
+        DispatchQueue.main.async {
+            switch (self.state) {
+            case .pending:
+                self.pendingWatchers.append(onResult)
+                break
+            case .resolved(let result):
+                onResult(result)
+                break
+            }
+        }
+    }
+}
+
+class DeepLinkFingerprinter : NSObject, WKScriptMessageHandler, WKNavigationDelegate {
+    fileprivate static let printDustRuntimeUrl = "https://pd.app.delivery"
+    fileprivate static let printDustHandlerName = "printHandler"
+
+    fileprivate var webView : WKWebView?
+    fileprivate let fingerprint : Deferred<[String:String]>
+
+    override init() {
+        let controller = WKUserContentController()
+        let config = WKWebViewConfiguration()
+        config.userContentController = controller
+
+        webView = WKWebView(frame: UIScreen.main.bounds, configuration: config)
+        fingerprint = Deferred()
+
+        super.init()
+
+        controller.add(self, name: DeepLinkFingerprinter.printDustHandlerName)
+
+        let request = URLRequest(url: URL(string: DeepLinkFingerprinter.printDustRuntimeUrl)!, cachePolicy: .returnCacheDataElseLoad, timeoutInterval: 10)
+        webView?.load(request)
+    }
+
+    func getFingerprintComponents(_ onGenerated: @escaping ([String:String]) -> Void) {
+        fingerprint.then(onResult: onGenerated)
+    }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        if message.name != DeepLinkFingerprinter.printDustHandlerName {
+            return;
+        }
+
+        let body = message.body as! NSDictionary
+        let type = body["type"] as! String
+
+        switch (type) {
+        case PrintDustMessage.clientReady.rawValue:
+            postClientMessage(type: PrintDustMessage.requestFingerprint.rawValue, data: nil)
+            break;
+        case PrintDustMessage.clientFingerprintGeneraged.rawValue:
+            guard let data = body["data"] as? [String:AnyObject],
+                  let components = data["components"] as? [String:String] else {
+                return
+            }
+            fingerprint.resolve(result: components)
+            DispatchQueue.main.async { self.cleanUpWebView() }
+            break;
+        default:
+            print("Unhandled message: \(type)")
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        // TODO: Reject?
+        print("Failed navigation \(error)")
+        DispatchQueue.main.async { self.cleanUpWebView() }
+    }
+
+    fileprivate func postClientMessage(type: String, data: Any?) {
+        do {
+            let msg: [String: Any] = ["type" : type, "data" : data != nil ? data! : NSNull()]
+            let json : Data = try JSONSerialization.data(withJSONObject: msg, options: JSONSerialization.WritingOptions(rawValue: 0))
+
+
+            let jsonMsg = String(data: json, encoding: .utf8)
+            let evalString = String(format: "postHostMessage(%@);", jsonMsg!)
+
+            webView?.evaluateJavaScript(evalString, completionHandler: nil)
+        } catch {
+            //Noop / reject?
+        }
+      }
+
+    fileprivate func cleanUpWebView() {
+        webView?.stopLoading()
+        webView?.configuration.userContentController.removeScriptMessageHandler(forName: DeepLinkFingerprinter.printDustHandlerName)
+        webView = nil
+    }
+}

--- a/Sources/SDK/DeepLinkFingerprinter.swift
+++ b/Sources/SDK/DeepLinkFingerprinter.swift
@@ -19,7 +19,6 @@ fileprivate enum DeferredState<R> {
     case resolved(R)
 }
 
-// TODO: consider rejection / timeouts?
 fileprivate class Deferred<R> {
     var state : DeferredState<R>
     var pendingWatchers : [(R) -> Void]
@@ -113,8 +112,6 @@ class DeepLinkFingerprinter : NSObject, WKScriptMessageHandler, WKNavigationDele
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        // TODO: Reject?
-        print("Failed navigation \(error)")
         DispatchQueue.main.async { self.cleanUpWebView() }
     }
 
@@ -129,7 +126,7 @@ class DeepLinkFingerprinter : NSObject, WKScriptMessageHandler, WKNavigationDele
 
             webView?.evaluateJavaScript(evalString, completionHandler: nil)
         } catch {
-            //Noop / reject?
+            // Noop
         }
       }
 

--- a/Sources/SDK/InApp/InAppHelper.swift
+++ b/Sources/SDK/InApp/InAppHelper.swift
@@ -297,7 +297,7 @@ internal class InAppHelper {
                 
                 self.syncBarrier.signal()
                 
-            }, onFailure: { response, error in
+            }, onFailure: { response, error, data in
                 if onComplete != nil {
                     onComplete?(-1)
                 }

--- a/Sources/SDK/KSAPIOperation.swift
+++ b/Sources/SDK/KSAPIOperation.swift
@@ -8,7 +8,7 @@ import Foundation
 public typealias KSAPIOperationSuccessBlock = ((KSResponse, KSAPIOperation)->Void)?
 public typealias KSAPIOperationFailureBlock = ((NSError?, KSAPIOperation)->Void)?
 
-protocol KSAPIOperationDelegate: class {
+protocol KSAPIOperationDelegate: AnyObject {
     func didComplete(_ operation: KSAPIOperation, results: KSResponse)
     func didFail(_ operation: KSAPIOperation, error: NSError?)
 }

--- a/Sources/SDK/KSAPIOperation.swift
+++ b/Sources/SDK/KSAPIOperation.swift
@@ -123,7 +123,7 @@ open class KSAPIOperation: Operation {
             {
                 self.onRequestError()
             }
-        }) { (response, error) in
+        }) { (response, error, data) in
             Kumulos.apiMethodRequestComplete()
 
             self.delegate?.didFail(self, error: nil)

--- a/Sources/SDK/Kumulos+DeepLinking.swift
+++ b/Sources/SDK/Kumulos+DeepLinking.swift
@@ -149,7 +149,7 @@ class DeepLinkHelper {
                 self.invokeDeepLinkHandler(.lookupFailed(url))
                 break
             }
-        }, onFailure: { (res, err) in
+        }, onFailure: { (res, err, data) in
             switch res?.statusCode {
             case 404:
                 self.invokeDeepLinkHandler(.linkNotFound(url))

--- a/Sources/SDK/Kumulos+DeepLinking.swift
+++ b/Sources/SDK/Kumulos+DeepLinking.swift
@@ -182,6 +182,8 @@ class DeepLinkHelper {
             switch res?.statusCode {
             case 200:
                 guard let jsonData = data as? Data,
+                      let response = try? JSONSerialization.jsonObject(with: jsonData) as? [AnyHashable:Any],
+                      let url = URL(string: response["linkUrl"] as! String),
                       let link = DeepLink(for: url, from: jsonData) else {
                     self.invokeDeepLinkHandler(.lookupFailed(url))
                     return

--- a/Sources/SDK/Kumulos.swift
+++ b/Sources/SDK/Kumulos.swift
@@ -10,7 +10,7 @@ import UserNotifications
 /*!
  *  The KumulosDelegate defines the methods for completion or failure of Kumulos operations.
  */
-protocol KumulosDelegate: class {
+protocol KumulosDelegate: AnyObject {
     func didComplete(_ kumulos: Kumulos, operation: KSAPIOperation, method: String, results: KSResponse)
     func didFail(_ kumulos: Kumulos, operation: KSAPIOperation, error: NSError?)
 }
@@ -214,7 +214,7 @@ open class Kumulos {
         sessionHelper.initialize()
         inAppHelper.initialize()
         _ = pushHelper.pushInit
-        deepLinkHelper?.checkForDeferredLink()
+        deepLinkHelper?.checkForNonContinuationLinkMatch()
     }
 
     deinit {

--- a/Sources/SDK/KumulosCheckins.swift
+++ b/Sources/SDK/KumulosCheckins.swift
@@ -189,7 +189,7 @@ public class KumulosCheckinClient {
         do {
             let reqData = try jsonEncoder.encode(CheckinRequestData(deviceKey: deviceKey(), checkin: checkin))
 
-            httpClient.sendRequest(.POST, toPath: path, data: reqData, onSuccess: makeSuccessHandler(201, KumulosCheckin.self, onComplete)) { (res, err) in
+            httpClient.sendRequest(.POST, toPath: path, data: reqData, onSuccess: makeSuccessHandler(201, KumulosCheckin.self, onComplete)) { (res, err, data) in
                 onComplete(.failure(.networkError(err)))
             }
         } catch {
@@ -202,7 +202,7 @@ public class KumulosCheckinClient {
         let encodedKey = KSHttpUtil.urlEncode(deviceKey()) ?? ""
         let path = "/v1/users/\(encodedUserId)/open-checkins?deviceKey=\(encodedKey)"
 
-        httpClient.sendRequest(.GET, toPath: path, data: nil, onSuccess: makeSuccessHandler(200, [KumulosCheckin].self, onComplete)) { (res, err) in
+        httpClient.sendRequest(.GET, toPath: path, data: nil, onSuccess: makeSuccessHandler(200, [KumulosCheckin].self, onComplete)) { (res, err, data) in
             onComplete(.failure(.networkError(err)))
         }
     }
@@ -231,7 +231,7 @@ public class KumulosCheckinClient {
             return
         }
 
-        httpClient.sendRequest(.DELETE, toPath: path, data: nil, onSuccess: makeSuccessHandler(200, KumulosCheckin.self, onComplete)) { (res, err) in
+        httpClient.sendRequest(.DELETE, toPath: path, data: nil, onSuccess: makeSuccessHandler(200, KumulosCheckin.self, onComplete)) { (res, err, data) in
             onComplete(.failure(.networkError(err)))
         }
     }

--- a/Sources/SDK/KumulosPushChannels.swift
+++ b/Sources/SDK/KumulosPushChannels.swift
@@ -65,7 +65,7 @@ public class KumulosPushChannels {
             if let successBlock = request.successBlock {
                 successBlock?(self.readChannelsFromResponse(jsonResponse: (data as! [[String : AnyObject]])))
             }
-        }) { (response, error) in
+        }) { (response, error, data)  in
             if let failureBlock = request.failureBlock {
                 failureBlock?(error)
             }
@@ -128,7 +128,7 @@ public class KumulosPushChannels {
             if let successBlock = request.successBlock {
                 successBlock?([self.getChannelFromPayload(payload: (data as! [String : AnyObject]))])
             }
-        }) { (response, error) in
+        }) { (response, error, data) in
             if let failureBlock = request.failureBlock {
                 failureBlock?(error)
             }
@@ -236,7 +236,7 @@ public class KumulosPushChannels {
             if let successBlock = request.successBlock {
                 successBlock?()
             }
-        }) { (response, error) in
+        }) { (response, error, data) in
             if let failureBlock = request.failureBlock {
                 failureBlock?(error)
             }

--- a/Sources/Shared/AnalyticsHelper.swift
+++ b/Sources/Shared/AnalyticsHelper.swift
@@ -236,7 +236,7 @@ internal class AnalyticsHelper {
                 return
             }
             self.syncEvents(context: context, onSyncComplete)
-        }) { (response, error) in
+        }) { (response, error, data) in
             print("Failed to send events")
             onSyncComplete?(error)
         }

--- a/Sources/Shared/KSHttp.swift
+++ b/Sources/Shared/KSHttp.swift
@@ -13,7 +13,7 @@ enum KSHttpError : Error {
 }
 
 typealias KSHttpSuccessBlock = (_ response:HTTPURLResponse?, _ decodedBody:Any?) -> Void
-typealias KSHttpFailureBlock = (_ response:HTTPURLResponse?, _ error:Error?) -> Void
+typealias KSHttpFailureBlock = (_ response:HTTPURLResponse?, _ error:Error?, _ decodedBody: Any?) -> Void
 
 enum KSHttpDataFormat {
     case json
@@ -159,12 +159,12 @@ internal class KSHttpClient {
     fileprivate func sendRequest(request:URLRequest, onSuccess:@escaping KSHttpSuccessBlock, onFailure:@escaping KSHttpFailureBlock) -> URLSessionDataTask {
         let task = urlSession.dataTask(with: request) { (data, response, error) in
             guard let httpResponse = response as? HTTPURLResponse else {
-                onFailure(nil, KSHttpError.responseCastingError)
+                onFailure(nil, KSHttpError.responseCastingError, nil)
                 return
             }
 
             if error != nil {
-                onFailure(httpResponse, error)
+                onFailure(httpResponse, error, nil)
                 return
             }
 
@@ -175,7 +175,7 @@ internal class KSHttpClient {
             }
 
             if httpResponse.statusCode > 299 {
-                onFailure(httpResponse, KSHttpError.badStatusCode)
+                onFailure(httpResponse, KSHttpError.badStatusCode, decodedBody)
                 return;
             }
 


### PR DESCRIPTION
### Description of Changes

To offer a better user experience for Web-to-App banners in the case where the user already has the app installed but we don't know about it, try to match the user's banner tap based on hashed fingerprint components.

The fingerprinting is done by a web-hosted runtime shared between the Web SDK and native SDKs in a webview.

This PR adds functionality to that effect:

- Check for DDL from clipboard once only (keeps existing behaviour)
- When no clipboard match is found, use `WKWebView` to run the fingerprinting algorithm
- Look for a match to the hashed fingerprint components to resolve the DDL
- Invoke the configured deep link handler for fingerprint matches
- In the case where a user lands from the continuation handler, don't perform a fingerprint lookup as it is unnecessary (the continuation was provided by the OS universal link handler)
- Note the failure path for fingerprint matching handles expiry and over limit cases, but practically these can't be reached as there is no way to configure these fields for web-to-app banners in the product. Keeping the code to allow easy expansion of the config options in the future if desired.

In addition:

- Update project settings
- Fix two warnings

Test:

- [x] Continuation order in Storyboard app
- [x] Continuation order in SceneDelegate app
- [x] Fingerprint tap lookup

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

