### PR TITLE
IOS15 UNNotificationActionIcon support

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -627,7 +627,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.1.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -655,7 +655,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.1.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "9.0.0"
+  s.version = "9.1.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "9.0.0"
+  s.version = "9.1.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 9.0.0'
+pod 'KumulosSdkSwift', '~> 9.1.0'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 9.0.0
+github "Kumulos/KumulosSdkSwift" ~> 9.1.0
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.
@@ -43,7 +43,7 @@ In Xcode add a package dependency by selecting:
 File > Swift Packages > Add Package Dependency
 ```
 
-Choose this repository URL for the package repository and `9.0.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
+Choose this repository URL for the package repository and `9.1.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
 
 ## Initializing and using the SDK
 

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -104,14 +104,9 @@ public class KumulosNotificationService {
     
     @available(iOSApplicationExtension 15.0, *)
     fileprivate class func getButtonIcon(button:[AnyHashable:Any]) -> UNNotificationActionIcon? {
-        guard button["icon"] != nil else {
+        guard let icon = button["icon"] as? [String:String], let iconType = icon["type"], let iconId = icon["id"] else {
             return nil
         }
-        
-        let iconDict = button["icon"] as! [String:String]
-        
-        let iconType = iconDict["type"] as! String
-        let iconId = iconDict["iconId"] as! String
         
         if (iconType == "custom") {
             //TODO - What if this doesnt exist? Catch exception -> return nil?

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -87,12 +87,32 @@ public class KumulosNotificationService {
 
             let id = buttonDict["id"] as! String
             let text = buttonDict["text"] as! String
-
-            let action = UNNotificationAction(identifier: id, title: text, options: .foreground)
+            
+            let icon = getButtonIcon(button: buttonDict)
+            
+            let action = UNNotificationAction(identifier: id, title: text, options: .foreground, icon: icon)
             actionArray.add(action);
         }
 
         return actionArray;
+    }
+    
+    fileprivate class func getButtonIcon(button:AnyHashable:Any]) -> UNNotificationActionIcon? {
+        guard buttonDict["icon"] != nil else {
+            return nil
+        }
+        
+        let iconDict = buttonDict["icon"] as! [String:String]
+        
+        let iconType = iconDict["type"] as !String
+        let iconId = iconDict["iconId"] as !String
+        
+        if (iconType === "custom") {
+            //TODO - What if this doesnt exist? Catch exception -> return nil?
+            return UNNotificationActionIcon(templateImageName: iconId)
+        }
+        
+        return UNNotificationActionIcon(systemImageName: iconId)
     }
 
     fileprivate class func addCategory(bestAttemptContent: UNMutableNotificationContent, actionArray:NSMutableArray, id: Int) {

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -88,7 +88,7 @@ public class KumulosNotificationService {
             let id = buttonDict["id"] as! String
             let text = buttonDict["text"] as! String
             
-            if #available(iOSApplicationExtension 15.0, *) {
+            if #available(iOS 15.0, *) {
                 let icon = getButtonIcon(button: buttonDict)
                 let action = UNNotificationAction(identifier: id, title: text, options: .foreground, icon: icon)
                 actionArray.add(action);
@@ -102,7 +102,7 @@ public class KumulosNotificationService {
         return actionArray;
     }
     
-    @available(iOSApplicationExtension 15.0, *)
+    @available(iOS 15.0, *)
     fileprivate class func getButtonIcon(button:[AnyHashable:Any]) -> UNNotificationActionIcon? {
         guard let icon = button["icon"] as? [String:String], let iconType = icon["type"], let iconId = icon["id"] else {
             return nil

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -90,6 +90,7 @@ public class KumulosNotificationService {
             
             let icon = getButtonIcon(button: buttonDict)
             
+            //TODO - Necessary to guard this constructor with 15+ ?
             let action = UNNotificationAction(identifier: id, title: text, options: .foreground, icon: icon)
             actionArray.add(action);
         }

--- a/Sources/Extension/KumulosNotificationService.swift
+++ b/Sources/Extension/KumulosNotificationService.swift
@@ -88,27 +88,32 @@ public class KumulosNotificationService {
             let id = buttonDict["id"] as! String
             let text = buttonDict["text"] as! String
             
-            let icon = getButtonIcon(button: buttonDict)
+            if #available(iOSApplicationExtension 15.0, *) {
+                let icon = getButtonIcon(button: buttonDict)
+                let action = UNNotificationAction(identifier: id, title: text, options: .foreground, icon: icon)
+                actionArray.add(action);
+            } else {
+                let action = UNNotificationAction(identifier: id, title: text, options: .foreground)
+                actionArray.add(action);
+            }
             
-            //TODO - Necessary to guard this constructor with 15+ ?
-            let action = UNNotificationAction(identifier: id, title: text, options: .foreground, icon: icon)
-            actionArray.add(action);
         }
 
         return actionArray;
     }
     
-    fileprivate class func getButtonIcon(button:AnyHashable:Any]) -> UNNotificationActionIcon? {
-        guard buttonDict["icon"] != nil else {
+    @available(iOSApplicationExtension 15.0, *)
+    fileprivate class func getButtonIcon(button:[AnyHashable:Any]) -> UNNotificationActionIcon? {
+        guard button["icon"] != nil else {
             return nil
         }
         
-        let iconDict = buttonDict["icon"] as! [String:String]
+        let iconDict = button["icon"] as! [String:String]
         
-        let iconType = iconDict["type"] as !String
-        let iconId = iconDict["iconId"] as !String
+        let iconType = iconDict["type"] as! String
+        let iconId = iconDict["iconId"] as! String
         
-        if (iconType === "custom") {
+        if (iconType == "custom") {
             //TODO - What if this doesnt exist? Catch exception -> return nil?
             return UNNotificationActionIcon(templateImageName: iconId)
         }

--- a/Sources/SDK/Kumulos.swift
+++ b/Sources/SDK/Kumulos.swift
@@ -59,7 +59,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "9.0.0"
+    internal let sdkVersion : String = "9.1.0"
 
     var networkRequestsInProgress = 0
 


### PR DESCRIPTION
### Description of Changes

Add support for UNNotificationActionIcon on notification buttons, added with iOS 15

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

Post Release:

Update docs site with correct version number references

- [x] https://docs.kumulos.com/developer-guide/sdk-reference/swift/
- [x] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [x] https://docs.kumulos.com/developer-guide/sdk-reference/swift/#changelog
