### PR TITLE
Refactor InAppDeepLinkHandlerBlock to expose in-app message data

### DIFF
--- a/KumulosSDK.xcodeproj/project.pbxproj
+++ b/KumulosSDK.xcodeproj/project.pbxproj
@@ -448,7 +448,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.13.0;
+				MARKETING_VERSION = 9.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -482,7 +482,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.13.0;
+				MARKETING_VERSION = 9.0.0;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift.KumulosSDKExtension;
@@ -627,7 +627,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.13.0;
+				MARKETING_VERSION = 9.0.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;
@@ -655,7 +655,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 8.13.0;
+				MARKETING_VERSION = 9.0.0;
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kumulos.swift;

--- a/KumulosSdkSwift.podspec
+++ b/KumulosSdkSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwift"
-  s.version = "8.13.0"
+  s.version = "9.0.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/KumulosSdkSwiftExtension.podspec
+++ b/KumulosSdkSwiftExtension.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "KumulosSdkSwiftExtension"
-  s.version = "8.13.0"
+  s.version = "9.0.0"
   s.license = "MIT"
   s.summary = "Official Swift SDK for integrating Kumulos services with your mobile apps"
   s.homepage = "https://github.com/Kumulos/KumulosSdkSwift"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Select an installation method below to get started.
 Add the following line to your app's target in your `Podfile`:
 
 ```
-pod 'KumulosSdkSwift', '~> 8.13.0'
+pod 'KumulosSdkSwift', '~> 9.0.0'
 ```
 
 Run `pod install` to install your dependencies.
@@ -19,7 +19,7 @@ Run `pod install` to install your dependencies.
 Add the following line to your `Cartfile`:
 
 ```
-github "Kumulos/KumulosSdkSwift" ~> 8.13.0
+github "Kumulos/KumulosSdkSwift" ~> 9.0.0
 ```
 
 Run `carthage update` to install your dependencies then follow the [Carthage integration steps](https://github.com/Carthage/Carthage#getting-started) to link the framework with your project.
@@ -43,7 +43,7 @@ In Xcode add a package dependency by selecting:
 File > Swift Packages > Add Package Dependency
 ```
 
-Choose this repository URL for the package repository and `8.13.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
+Choose this repository URL for the package repository and `9.0.0` for the version where prompted. You can then follow the integration steps below or read the full [Kumulos Swift integration guide](https://docs.kumulos.com/integration/swift) for more information.
 
 ## Initializing and using the SDK
 
@@ -77,4 +77,4 @@ This project is licensed under the MIT license with portions licensed under the 
 | ------------- | ------------------ |
 | 3.0           | 2.x                |
 | 4.2           | 4.x                |
-| 5.0           | 5.x, 6.x, 7.x, 8.x |
+| 5.0           | 5.x, 6.x, 7.x, 8.x, 9.x |

--- a/Sources/SDK/InApp/InAppModels.swift
+++ b/Sources/SDK/InApp/InAppModels.swift
@@ -37,7 +37,7 @@ class InAppMessageEntity : NSManagedObject {
     }
 }
 
-public class InAppMessage: NSObject {
+class InAppMessage: NSObject {
     internal(set) open var id: Int64
     internal(set) open var updatedAt: NSDate
     internal(set) open var content: NSDictionary
@@ -66,5 +66,17 @@ public class InAppMessage: NSObject {
         }
 
         return super.isEqual(object)
+    }
+}
+
+public struct InAppButtonPress {
+    let deepLinkData : [AnyHashable:Any]
+    let messageId : Int64
+    let messageData : NSDictionary?
+
+    init(deepLinkData:[AnyHashable:Any], messageId:Int64, messageData:NSDictionary?) {
+        self.deepLinkData = deepLinkData
+        self.messageId = messageId
+        self.messageData = messageData
     }
 }

--- a/Sources/SDK/InApp/InAppPresenter.swift
+++ b/Sources/SDK/InApp/InAppPresenter.swift
@@ -392,13 +392,13 @@ class InAppPresenter : NSObject, WKScriptMessageHandler, WKNavigationDelegate{
             }
 
             if (userAction != nil) {
-                self.handleUserAction(userAction: userAction!)
+                self.handleUserAction(message: message, userAction: userAction!)
                 self.cancelCurrentPresentationQueue(waitForViewCleanup: true)
             }
         }
     }
 
-    func handleUserAction(userAction: NSDictionary) -> Void {
+    func handleUserAction(message: InAppMessage, userAction: NSDictionary) -> Void {
         let type = userAction["type"] as! String
                 
         if (type == InAppAction.PROMPT_PUSH_PERMISSION.rawValue) {
@@ -409,7 +409,8 @@ class InAppPresenter : NSObject, WKScriptMessageHandler, WKNavigationDelegate{
             }
             DispatchQueue.main.async {
                 let data = userAction.value(forKeyPath: "data.deepLink") as? [AnyHashable:Any] ?? [:]
-                Kumulos.sharedInstance.config.inAppDeepLinkHandlerBlock?(data)
+                let buttonPress = InAppButtonPress(deepLinkData: data, messageId: message.id, messageData: message.data)
+                Kumulos.sharedInstance.config.inAppDeepLinkHandlerBlock?(buttonPress)
             }
         } else if (type == InAppAction.OPEN_URL.rawValue) {
             guard let url = URL(string: userAction.value(forKeyPath: "data.url") as! String) else {

--- a/Sources/SDK/Kumulos.swift
+++ b/Sources/SDK/Kumulos.swift
@@ -59,7 +59,7 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "8.13.0"
+    internal let sdkVersion : String = "9.0.0"
 
     var networkRequestsInProgress = 0
 

--- a/Sources/SDK/Kumulos.swift
+++ b/Sources/SDK/Kumulos.swift
@@ -33,7 +33,7 @@ internal enum KumulosEvent : String {
     case MESSAGE_READ = "k.message.read"
 }
 
-public typealias InAppDeepLinkHandlerBlock = ([AnyHashable:Any]) -> Void
+public typealias InAppDeepLinkHandlerBlock = (InAppButtonPress) -> Void
 public typealias PushOpenedHandlerBlock = (KSPushNotification) -> Void
 
 @available(iOS 10.0, *)


### PR DESCRIPTION
### Description of Changes

Refactor InAppDeepLinkHandlerBlock to expose in-app message data.

The InAppButtonPress struct contains the original deep link button data in the deepLinkData field, and additionally offers the in-app message's ID and (optional) data field.

<img width="631" alt="Screenshot 2021-09-08 at 10 42 52" src="https://user-images.githubusercontent.com/1305158/132714660-3bf235bb-897b-4402-b4df-1b5af504f33b.png">

### Breaking Changes

- InAppDeepLinkHandlerBlock now takes InAppButtonPress as its only argument
- InAppMessage model is no longer public (the class is for internal SDK use)

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Check `pod lib lint` passes

Bump versions in:

-   [x] `Sources/Kumulos.swift`
-   [x] `KumulosSdkSwift.podspec`
-   [x] `KumulosSdkSwiftExtension.podspec`
-   [x] `Build target version for plist`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `pod trunk push` to publish to CocoaPods

Post Release:

Update docs site with correct version number references

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/swift/
- [ ] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/swift/#changelog
